### PR TITLE
final ci fix

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -2,8 +2,6 @@ name: Pre-commit
 
 on:
   pull_request:
-  push:
-    branches: [main]
 
 jobs:
   pre-commit:

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -136,7 +136,7 @@ A rule that just restates what the linter already enforces doesn't need to be th
 
 ## CI
 
-Runs on every PR and every push to `main`:
+`CI` and `Build` run on every PR and every push to `main`. `Pre-commit` runs on the PR only, not on push, so it never fails the way it did before: rerunning `no-commit-to-branch` against a commit that is already on `main` fails by definition, since the commit reviewed on the PR is the same one that lands on `main`, there is nothing new to check on push.
 
 | Workflow | Job(s) | What it checks |
 | --- | --- | --- |


### PR DESCRIPTION
This pull request updates the pre-commit workflow configuration and clarifies related documentation. The main focus is to ensure the `Pre-commit` workflow only runs on pull requests and not on direct pushes to the `main` branch, preventing unnecessary failures. The documentation is updated to reflect this change and explain the reasoning.

Workflow configuration changes:

* Updated `.github/workflows/pre-commit.yaml` to remove the trigger for pushes to `main`, so the `Pre-commit` job only runs on pull requests.

Documentation updates:

* Updated `docs/development/contributing.md` to clarify that `Pre-commit` runs only on PRs (not on pushes), and explained why this avoids failures from rerunning checks on commits that have already landed on `main`.