### PR TITLE
docs

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,16 +1,9 @@
 # Markdownlint configuration
 # https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.yaml
 
-# MD013/line-length
-MD013:
-  line_length: 120
-  heading_line_length: 120
-  code_block_line_length: 120
-  code_blocks: false
-  tables: false
-  headings: true
-  strict: false
-  stern: false
+# MD013/line-length: off. House style is sentence-per-line, not character-wrapped, so a
+# long sentence or a long URL on one line is expected, not a defect.
+MD013: false
 
 # Allow HTML needed by MkDocs Material (grids, admonitions)
 MD033:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 # Nyctea
 
+[![PyPI](https://img.shields.io/pypi/v/nyctea.svg)](https://pypi.org/project/nyctea/)
+[![Python versions](https://img.shields.io/pypi/pyversions/nyctea.svg)](https://pypi.org/project/nyctea/)
+[![License](https://img.shields.io/pypi/l/nyctea.svg)](https://github.com/yannick-vinkesteijn/nyctea/blob/main/LICENSE)
+[![CI](https://github.com/yannick-vinkesteijn/nyctea/actions/workflows/ci.yaml/badge.svg)](https://github.com/yannick-vinkesteijn/nyctea/actions/workflows/ci.yaml)
+
 Polars-based data validation library with an extensible OOP validator architecture.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img align="center" width="150" height="150" src="docs/assets/logo-nyctea.png" alt="Nyctea logo">
+<img align="center" width="150" height="150" src="https://nyctea.vinkesteijn.io/assets/logo-nyctea.png" alt="Nyctea logo">
 
 # Nyctea
 
@@ -147,16 +147,16 @@ CI runs linting, type checking, and the test suite on Python 3.11 through 3.14 f
 
 ## Documentation
 
-- **[Quickstart](docs/user-guide/quickstart.md)**: getting started guide
-- **[Features](docs/user-guide/features.md)**: schema syntax and validator capabilities
-- **[Registry guide](docs/user-guide/registry.md)**: registering and discovering validators
-- **[API reference](docs/api/index.md)**: full public API
-- **[Breaking changes](docs/releases/breaking-changes.md)**: migrating between versions
+- **[Quickstart](https://nyctea.vinkesteijn.io/user-guide/quickstart/)**: getting started guide
+- **[Features](https://nyctea.vinkesteijn.io/user-guide/features/)**: schema syntax and validator capabilities
+- **[Registry guide](https://nyctea.vinkesteijn.io/user-guide/registry/)**: registering and discovering validators
+- **[API reference](https://nyctea.vinkesteijn.io/api/)**: full public API
+- **[Breaking changes](https://nyctea.vinkesteijn.io/releases/breaking-changes/)**: migrating between versions
 
 ## Contributing
 
 Contributions are welcome. Open an issue before starting anything beyond a trivial fix; see
-[docs/development/contributing.md](docs/development/contributing.md) for the full workflow
+[docs/development/contributing.md](https://nyctea.vinkesteijn.io/development/contributing/) for the full workflow
 (issue-first, branch and PR conventions, CI overview) and
 [DEVELOPMENT.md](DEVELOPMENT.md) for local setup.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nyctea"
-version = "0.2.0b1"
+version = "0.2.0b2"
 description = "Polars-based data validation library with an extensible OOP validator architecture"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -29,8 +29,10 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/yannick-vinkesteijn/nyctea"
+Documentation = "https://nyctea.vinkesteijn.io/"
 Repository = "https://github.com/yannick-vinkesteijn/nyctea"
 Issues = "https://github.com/yannick-vinkesteijn/nyctea/issues"
+Changelog = "https://github.com/yannick-vinkesteijn/nyctea/releases"
 
 [build-system]
 requires = ["uv_build>=0.9.17,<0.10.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -755,7 +755,7 @@ wheels = [
 
 [[package]]
 name = "nyctea"
-version = "0.2.0b1"
+version = "0.2.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "polars" },

--- a/zensical.toml
+++ b/zensical.toml
@@ -4,7 +4,7 @@
 site_name = "Nyctea Documentation"
 site_description = "Polars-optimized data validation library with Pydantic schemas"
 site_author = "Nyctea Contributors"
-# site_url = "https://nyctea.readthedocs.io"
+site_url = "https://nyctea.vinkesteijn.io/"
 
 copyright = """
 Copyright &copy; 2025 Nyctea Contributors. MIT License.


### PR DESCRIPTION
This pull request updates documentation references and configuration to point to the new official documentation site, and simplifies markdown linting configuration for consistency with the project's writing style.

Documentation and URL updates:

* Updated all documentation links in `README.md` to use the new official site (`https://nyctea.vinkesteijn.io`) instead of relative or old paths. This ensures users always access the latest documentation.
* Changed the logo URL in `README.md` to point directly to the hosted asset on the new documentation site.
* Set the `site_url` in `zensical.toml` to the new documentation site, reflecting the updated canonical location.

Linting configuration:

* Disabled the `MD013/line-length` rule in `.markdownlint.yaml` to align with the project's sentence-per-line markdown style, preventing false positives on long lines.