### PR TITLE
fix for silently failing null checks + failing to enforce

### DIFF
--- a/src/nyctea/schema/validator.py
+++ b/src/nyctea/schema/validator.py
@@ -207,7 +207,8 @@ class SchemaValidator:
         Excludes the built-in not-null check, which is already enforced directly in
         ``ColumnCheckPhase`` and can never resolve to ``'null'`` (nullable=False is
         required for that check to exist, and the guard in ``resolve_on_failure``
-        forces non-nullable columns to ``'raise'``).
+        rewrites ``'null'`` to ``'raise'`` for non-nullable columns; ``'ignore'`` is
+        unaffected and can still apply).
 
         Args:
             context: Pipeline context with populated check_masks.

--- a/src/nyctea/schema/validator.py
+++ b/src/nyctea/schema/validator.py
@@ -10,6 +10,7 @@ import polars as pl
 
 from nyctea.engine.context import PipelineContext
 from nyctea.engine.factory import create_pipeline_from_schema
+from nyctea.engine.phases import NOT_NULL_CHECK
 from nyctea.engine.pipeline import ValidationPipeline
 from nyctea.engine.validate import ErrorReportConfig, ValidationReport, ValidationResult
 from nyctea.exceptions import PipelineError
@@ -127,9 +128,14 @@ class SchemaValidator:
 
         # Enforce on_failure=raise (targeted collect of counts only)
         self._enforce_coercion_raise(context)
+        self._enforce_check_raise(context)
 
-        # Build errors (targeted collect of mask + relevant columns only)
+        # Build errors before nulling failures, so the report reflects the
+        # original failing values (targeted collect of mask + relevant columns only)
         errors = self._build_errors(context)
+
+        # Apply on_failure=null: null out values that failed a check
+        self._apply_check_null(context)
 
         # Build report (targeted collect of row count only)
         report = self._build_report(context)
@@ -194,6 +200,96 @@ class SchemaValidator:
                     f"{schema.columns[col_name].dtype}",
                     phase="coercion",
                 )
+
+    def _check_masks_by_column(self, context: PipelineContext, on_failure: str) -> dict[str, list[str]]:
+        """Group check mask aliases by column for columns resolving to the given on_failure.
+
+        Excludes the built-in not-null check, which is already enforced directly in
+        ``ColumnCheckPhase`` and can never resolve to ``'null'`` (nullable=False is
+        required for that check to exist, and the guard in ``resolve_on_failure``
+        forces non-nullable columns to ``'raise'``).
+
+        Args:
+            context: Pipeline context with populated check_masks.
+            on_failure: The resolved on_failure behavior to filter columns by.
+
+        Returns:
+            Mapping of column name to the list of mask aliases for its checks.
+        """
+        schema = context.schema
+        grouped: dict[str, list[str]] = {}
+        for (col_name, check_name), alias in context.check_masks.items():
+            if check_name == NOT_NULL_CHECK:
+                continue
+            if schema.resolve_on_failure(col_name) != on_failure:
+                continue
+            grouped.setdefault(col_name, []).append(alias)
+        return grouped
+
+    def _enforce_check_raise(self, context: PipelineContext) -> None:
+        """Raise PipelineError if any on_failure=raise column failed a check.
+
+        Uses a targeted collect of only the per-column failure counts (1-row
+        aggregation), not the full data.
+
+        Args:
+            context: Pipeline context with check_masks populated.
+
+        Raises:
+            PipelineError: If any on_failure=raise column has a failing check.
+        """
+        raise_cols = self._check_masks_by_column(context, "raise")
+        if not raise_cols:
+            return
+
+        count_exprs = [
+            pl.any_horizontal([~pl.col(alias) for alias in aliases]).sum().alias(f"__check_fail__{col_name}")
+            for col_name, aliases in raise_cols.items()
+        ]
+        counts = _collect(context.data.select(count_exprs))
+        for col_name in raise_cols:
+            fail_count = int(counts[f"__check_fail__{col_name}"].item())
+            if fail_count > 0:
+                raise PipelineError(
+                    f"Check failed for column '{col_name}': {fail_count} value(s) failed "
+                    f"validation and on_failure is 'raise'.",
+                    phase="column_checks",
+                )
+
+    def _apply_check_null(self, context: PipelineContext) -> None:
+        """Null out values that failed a check on an on_failure=null column.
+
+        A value is nulled if any of its column's checks failed. Runs after
+        ``_build_errors`` so the error report still reflects the original
+        failing values.
+
+        Args:
+            context: Pipeline context with check_masks populated. Mutates
+                ``context.data`` and ``context.nullified_counts`` in place.
+        """
+        null_cols = self._check_masks_by_column(context, "null")
+        if not null_cols:
+            return
+
+        fail_exprs = {
+            col_name: pl.any_horizontal([~pl.col(alias) for alias in aliases])
+            for col_name, aliases in null_cols.items()
+        }
+        counts = _collect(
+            context.data.select(
+                [expr.sum().alias(f"__check_fail__{col_name}") for col_name, expr in fail_exprs.items()]
+            )
+        )
+        for col_name in null_cols:
+            context.nullified_counts[col_name] = context.nullified_counts.get(col_name, 0) + int(
+                counts[f"__check_fail__{col_name}"].item()
+            )
+
+        null_exprs = [
+            pl.when(fail_expr).then(None).otherwise(pl.col(col_name)).alias(col_name)
+            for col_name, fail_expr in fail_exprs.items()
+        ]
+        context.data = context.data.with_columns(null_exprs)
 
     def _build_report(self, context: PipelineContext) -> ValidationReport:
         """Stub — row counts only. Replaced by ReportGenerationPhase (Step 4)."""

--- a/tests/engine/test_phases.py
+++ b/tests/engine/test_phases.py
@@ -427,8 +427,8 @@ class TestFullPipeline:
         schema = SchemaModel.from_dict(
             {
                 "columns": {
-                    "a": {"dtype": "Int64", "nullable": True, "checks": [{"name": "b__c"}]},
-                    "a__b": {"dtype": "Int64", "nullable": True, "checks": [{"name": "c"}]},
+                    "a": {"dtype": "Int64", "nullable": True, "on_failure": "ignore", "checks": [{"name": "b__c"}]},
+                    "a__b": {"dtype": "Int64", "nullable": True, "on_failure": "ignore", "checks": [{"name": "c"}]},
                 }
             }
         )
@@ -531,7 +531,12 @@ class TestErrorReporting:
         schema = SchemaModel.from_dict(
             {
                 "columns": {
-                    "age": {"dtype": "Int64", "nullable": True, "checks": [{"name": "min_value", "args": {"min": 0}}]}
+                    "age": {
+                        "dtype": "Int64",
+                        "nullable": True,
+                        "on_failure": "ignore",
+                        "checks": [{"name": "min_value", "args": {"min": 0}}],
+                    }
                 }
             }
         )
@@ -547,7 +552,12 @@ class TestErrorReporting:
         schema = SchemaModel.from_dict(
             {
                 "columns": {
-                    "age": {"dtype": "Int64", "nullable": True, "checks": [{"name": "min_value", "args": {"min": 0}}]}
+                    "age": {
+                        "dtype": "Int64",
+                        "nullable": True,
+                        "on_failure": "ignore",
+                        "checks": [{"name": "min_value", "args": {"min": 0}}],
+                    }
                 }
             }
         )
@@ -562,7 +572,12 @@ class TestErrorReporting:
         schema = SchemaModel.from_dict(
             {
                 "columns": {
-                    "age": {"dtype": "Int64", "nullable": True, "checks": [{"name": "min_value", "args": {"min": 0}}]}
+                    "age": {
+                        "dtype": "Int64",
+                        "nullable": True,
+                        "on_failure": "ignore",
+                        "checks": [{"name": "min_value", "args": {"min": 0}}],
+                    }
                 }
             }
         )
@@ -577,7 +592,12 @@ class TestErrorReporting:
         schema = SchemaModel.from_dict(
             {
                 "columns": {
-                    "age": {"dtype": "Int64", "nullable": True, "checks": [{"name": "min_value", "args": {"min": 0}}]}
+                    "age": {
+                        "dtype": "Int64",
+                        "nullable": True,
+                        "on_failure": "ignore",
+                        "checks": [{"name": "min_value", "args": {"min": 0}}],
+                    }
                 }
             }
         )
@@ -589,7 +609,12 @@ class TestErrorReporting:
         schema = SchemaModel.from_dict(
             {
                 "columns": {
-                    "age": {"dtype": "Int64", "nullable": True, "checks": [{"name": "min_value", "args": {"min": 0}}]}
+                    "age": {
+                        "dtype": "Int64",
+                        "nullable": True,
+                        "on_failure": "ignore",
+                        "checks": [{"name": "min_value", "args": {"min": 0}}],
+                    }
                 }
             }
         )
@@ -603,7 +628,12 @@ class TestErrorReporting:
         schema = SchemaModel.from_dict(
             {
                 "columns": {
-                    "age": {"dtype": "Int64", "nullable": True, "checks": [{"name": "min_value", "args": {"min": 0}}]}
+                    "age": {
+                        "dtype": "Int64",
+                        "nullable": True,
+                        "on_failure": "ignore",
+                        "checks": [{"name": "min_value", "args": {"min": 0}}],
+                    }
                 }
             }
         )
@@ -619,6 +649,7 @@ class TestErrorReporting:
                     "age": {
                         "dtype": "Int64",
                         "nullable": True,
+                        "on_failure": "ignore",
                         "checks": [
                             {"name": "min_value", "args": {"min": 0}},
                             {"name": "between", "args": {"min": 0, "max": 100}},
@@ -646,7 +677,12 @@ class TestValidationReportSummary:
         schema = SchemaModel.from_dict(
             {
                 "columns": {
-                    "age": {"dtype": "Int64", "nullable": True, "checks": [{"name": "min_value", "args": {"min": 0}}]}
+                    "age": {
+                        "dtype": "Int64",
+                        "nullable": True,
+                        "on_failure": "ignore",
+                        "checks": [{"name": "min_value", "args": {"min": 0}}],
+                    }
                 }
             }
         )
@@ -811,3 +847,102 @@ class TestOnFailure:
         result = schema.validate(df, registry)
         assert result.report.on_failure == "null"
         assert "on_failure: null" in result.report.summary()
+
+    def test_check_raise_on_failure(self, registry):
+        """on_failure=raise + a failing check raises PipelineError, not just a recorded error."""
+        schema = SchemaModel.from_dict(
+            {
+                "on_failure": "raise",
+                "columns": {
+                    "age": {
+                        "dtype": "Int64",
+                        "nullable": True,
+                        "checks": [{"name": "min_value", "args": {"min": 0}}],
+                    }
+                },
+            }
+        )
+        df = pl.DataFrame({"age": [1, -5, 3]})
+        with pytest.raises(PipelineError, match="Check failed for column 'age'"):
+            schema.validate(df, registry)
+
+    def test_check_ignore_on_failure_does_not_raise(self, registry):
+        """on_failure=ignore records the failure but does not raise or nullify."""
+        schema = SchemaModel.from_dict(
+            {
+                "on_failure": "ignore",
+                "columns": {
+                    "age": {
+                        "dtype": "Int64",
+                        "nullable": True,
+                        "checks": [{"name": "min_value", "args": {"min": 0}}],
+                    }
+                },
+            }
+        )
+        df = pl.DataFrame({"age": [1, -5, 3]})
+        result = schema.validate(df, registry)
+        assert result.data.collect()["age"].to_list() == [1, -5, 3]
+        assert result.errors["count"].item() == 1
+
+    def test_check_null_on_failure_nullifies_failing_values(self, registry):
+        """on_failure=null nulls out values that failed a check, keeps passing values."""
+        schema = SchemaModel.from_dict(
+            {
+                "on_failure": "null",
+                "columns": {
+                    "age": {
+                        "dtype": "Int64",
+                        "nullable": True,
+                        "checks": [{"name": "min_value", "args": {"min": 0}}],
+                    }
+                },
+            }
+        )
+        df = pl.DataFrame({"age": [10, -1, 5, -3]})
+        result = schema.validate(df, registry)
+        assert result.data.collect()["age"].to_list() == [10, None, 5, None]
+
+    def test_check_null_on_failure_error_report_keeps_original_value(self, registry):
+        """The error report reflects the original failing value, not the post-nullification null."""
+        schema = SchemaModel.from_dict(
+            {
+                "on_failure": "null",
+                "columns": {
+                    "age": {
+                        "dtype": "Int64",
+                        "nullable": True,
+                        "checks": [{"name": "min_value", "args": {"min": 0}}],
+                    }
+                },
+            }
+        )
+        df = pl.DataFrame({"age": [10, -1]})
+        result = schema.validate(df, registry, error_report_config=ErrorReportConfig(mode="cells"))
+        assert result.errors["value"].to_list() == ["-1"]
+
+    def test_check_null_on_failure_only_nullifies_own_column(self, registry):
+        """Nullifying a failing on_failure=null column does not affect an unrelated raise column."""
+        schema = SchemaModel.from_dict(
+            {
+                "columns": {
+                    "age": {
+                        "dtype": "Int64",
+                        "nullable": True,
+                        "on_failure": "null",
+                        "checks": [{"name": "min_value", "args": {"min": 0}}],
+                    },
+                    "score": {
+                        "dtype": "Int64",
+                        "nullable": True,
+                        "on_failure": "ignore",
+                        "checks": [{"name": "min_value", "args": {"min": 0}}],
+                    },
+                },
+            }
+        )
+        df = pl.DataFrame({"age": [-1, 5], "score": [-1, 5]})
+        result = schema.validate(df, registry)
+        data = result.data.collect()
+        assert data["age"].to_list() == [None, 5]
+        assert data["score"].to_list() == [-1, 5]

--- a/tests/engine/test_phases.py
+++ b/tests/engine/test_phases.py
@@ -922,7 +922,7 @@ class TestOnFailure:
         assert result.errors["value"].to_list() == ["-1"]
 
     def test_check_null_on_failure_only_nullifies_own_column(self, registry):
-        """Nullifying a failing on_failure=null column does not affect an unrelated raise column."""
+        """Nullifying a failing on_failure=null column does not affect an unrelated ignore column."""
         schema = SchemaModel.from_dict(
             {
                 "columns": {

--- a/tests/test_validation_minimal.py
+++ b/tests/test_validation_minimal.py
@@ -46,6 +46,7 @@ def sample_schema():
                     ],
                     "nullable": False,
                     "required": True,
+                    "on_failure": "ignore",
                 },
                 "city": {
                     "dtype": "Utf8",

--- a/tests/validators/test_decorators.py
+++ b/tests/validators/test_decorators.py
@@ -148,6 +148,7 @@ class TestColumnCheckDecorator:
                         "parsers": [{"name": "to_int"}],
                         "checks": [{"name": "positive"}],
                         "nullable": False,
+                        "on_failure": "ignore",
                     },
                 }
             }


### PR DESCRIPTION
This pull request introduces robust handling of the `on_failure` parameter for column checks in the validation pipeline. Now, columns can be configured to either raise an error, nullify failing values, or simply record failures without interrupting validation. The implementation ensures that error reporting accurately reflects original data before any nullification, and that different `on_failure` modes are thoroughly tested.

**Validation logic improvements:**

* Added `_enforce_check_raise` and `_apply_check_null` methods to `validator.py`, enabling per-column enforcement of `on_failure=raise` (which raises an error if a check fails) and `on_failure=null` (which nullifies failing values after error reporting). [[1]](diffhunk://#diff-04be3d8f9465cc00ca9ce7120dd81281508fff1b975aa58ba3fa51672c0448e9R131-R139) [[2]](diffhunk://#diff-04be3d8f9465cc00ca9ce7120dd81281508fff1b975aa58ba3fa51672c0448e9R204-R293)
* Ensured error reports are generated before nullification, so they reflect the original failing values.

**Testing enhancements:**

* Added comprehensive tests for all `on_failure` behaviors (`raise`, `null`, `ignore`) in `test_phases.py`, verifying that each mode behaves as expected and that error reporting is accurate.
* Updated existing test schemas to explicitly set `on_failure: ignore`, making test expectations clear and consistent with the new logic. [[1]](diffhunk://#diff-cbed9af2ba967040ecf4a4f3d21714b5e951a574b1ee612baa2152321443db2bL430-R431) [[2]](diffhunk://#diff-cbed9af2ba967040ecf4a4f3d21714b5e951a574b1ee612baa2152321443db2bL534-R539) [[3]](diffhunk://#diff-cbed9af2ba967040ecf4a4f3d21714b5e951a574b1ee612baa2152321443db2bL550-R560) [[4]](diffhunk://#diff-cbed9af2ba967040ecf4a4f3d21714b5e951a574b1ee612baa2152321443db2bL565-R580) [[5]](diffhunk://#diff-cbed9af2ba967040ecf4a4f3d21714b5e951a574b1ee612baa2152321443db2bL580-R600) [[6]](diffhunk://#diff-cbed9af2ba967040ecf4a4f3d21714b5e951a574b1ee612baa2152321443db2bL592-R617) [[7]](diffhunk://#diff-cbed9af2ba967040ecf4a4f3d21714b5e951a574b1ee612baa2152321443db2bL606-R636) [[8]](diffhunk://#diff-cbed9af2ba967040ecf4a4f3d21714b5e951a574b1ee612baa2152321443db2bR652) [[9]](diffhunk://#diff-cbed9af2ba967040ecf4a4f3d21714b5e951a574b1ee612baa2152321443db2bL649-R685) [[10]](diffhunk://#diff-b240cf73af756de48c0201c05252e0990e6a9e4b7c0584e62639c32ff14c00a8R49) [[11]](diffhunk://#diff-18cf0b0faf80472f9d96eaa6ab937dc2c3a09cb201efd6c116cef04ad5137948R151)

**Internal refactoring:**

* Introduced `_check_masks_by_column` utility to group check masks by column and `on_failure` mode, improving code clarity and maintainability.

These changes provide more flexible and predictable validation outcomes, and make the behavior of the validation pipeline easier to test and reason about.