### PR TITLE
fix for coercion failures reports

### DIFF
--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -37,10 +37,11 @@ def positive(col: pl.Expr) -> pl.Expr:
 
 # 3. Define a schema
 schema = SchemaModel.from_dict({
+    "on_failure": "ignore",  # Record failures instead of raising
     "columns": {
         "age": {
             "dtype": "Int64",
-            "nullable": False,  # No nulls allowed
+            "nullable": False,  # Nulls are recorded as failures, not dropped (see on_failure above)
             "checks": [{"name": "positive"}]  # Must be positive
         },
         "name": {
@@ -61,12 +62,12 @@ result = schema.validate(df, registry)
 
 # 6. Check results
 print(result.report.summary())
-# Validation Report (on_failure: raise)
+# Validation Report (on_failure: ignore)
 # Rows: 2/4 valid (50.0%)
 #
 # Column Issues:
 #   age:
-#     Check failures: 1
+#     Check failures: 2
 #     Final nulls: 1
 
 print(result.errors)
@@ -77,7 +78,7 @@ print(result.errors)
 # │ str    ┆ str      ┆ u32   │
 # ╞════════╪══════════╪═══════╡
 # │ age    ┆ positive ┆ 1     │
-# │ age    ┆ non_null ┆ 1     │
+# │ age    ┆ not_null ┆ 1     │
 # └────────┴──────────┴───────┘
 ```
 
@@ -96,7 +97,7 @@ The report provides high-level statistics:
 ```python
 result.report.rows_processed  # Total rows: 4
 result.report.rows_valid      # Valid rows: 2
-result.report.on_failure      # "raise"
+result.report.on_failure      # "ignore"
 ```
 
 Per-column statistics:

--- a/src/nyctea/engine/phases.py
+++ b/src/nyctea/engine/phases.py
@@ -17,7 +17,10 @@ from nyctea.exceptions import PipelineError, ValidationError
 from nyctea.schema.model import SchemaModel
 
 NOT_NULL_CHECK = "not_null"
-"""Check name reported for a nullable=False column that contains nulls."""
+"""Check name reported for a nullable=False column that contains nulls. Frozen, see test_phases.py."""
+
+COERCION_CHECK = "coerce"
+"""Check name reported for a failed dtype cast. Frozen, see test_phases.py."""
 
 
 def _reject_alias_collision(alias: str, current_columns: list[str], phase: str, what: str) -> None:
@@ -288,9 +291,20 @@ class CoercionPhase(PipelinePhase):
             _reject_alias_collision(
                 f"__pre_null__{c}", current_dtypes.names(), self.name, f"the pre-null snapshot for column '{c}'"
             )
+            _reject_alias_collision(
+                f"__coercion_ok__{c}", current_dtypes.names(), self.name, f"the coercion mask for column '{c}'"
+            )
         pre_null_exprs = [pl.col(c).is_null().alias(f"__pre_null__{c}") for c in cols_to_cast]
         context.internal_columns.update(f"__pre_null__{c}" for c in cols_to_cast)
         context.data = lf.with_columns(pre_null_exprs).with_columns(cast_exprs)
+
+        # True = no coercion failure; feeds check_masks like a real check.
+        coercion_ok_exprs = [
+            (~(pl.col(c).is_null() & ~pl.col(f"__pre_null__{c}"))).alias(f"__coercion_ok__{c}") for c in cols_to_cast
+        ]
+        context.data = context.data.with_columns(coercion_ok_exprs)
+        context.internal_columns.update(f"__coercion_ok__{c}" for c in cols_to_cast)
+        context.check_masks.update({(c, COERCION_CHECK): f"__coercion_ok__{c}" for c in cols_to_cast})
 
         return context
 
@@ -343,8 +357,11 @@ class ColumnCheckPhase(PipelinePhase):
         # Build boolean mask columns for each check (True = passed)
         # No collect here — downstream phases use these masks lazily
         mask_exprs: list[pl.Expr] = []
-        check_masks: dict[tuple[str, str], str] = {}
+        # Preserve entries earlier phases (e.g. CoercionPhase) already registered.
+        check_masks: dict[tuple[str, str], str] = dict(context.check_masks)
         notnull_aliases = self._build_notnull_mask_exprs(schema, current_columns, mask_exprs)
+        # Independent of check_masks' size, so seeded coercion entries don't shift aliases.
+        check_index = 0
 
         for col_name, col_schema in schema.columns.items():
             checks_to_run = list(col_schema.checks) if col_schema.checks else []
@@ -353,6 +370,14 @@ class ColumnCheckPhase(PipelinePhase):
                 continue
 
             for check_spec in checks_to_run:
+                if check_spec.name == COERCION_CHECK and (col_name, COERCION_CHECK) in check_masks:
+                    raise PipelineError(
+                        f"Column '{col_name}' has coercion enabled and also has a check named "
+                        f"'{COERCION_CHECK}'. The name is reserved for the built-in coercion "
+                        f"failure tracking. Rename the check.",
+                        phase=self.name,
+                    )
+
                 try:
                     check = registry.column_checks.get(check_spec.name)
                 except KeyError as e:
@@ -374,7 +399,8 @@ class ColumnCheckPhase(PipelinePhase):
                 # Index, not "{col}__{check}": the latter is ambiguous, since a column named
                 # 'a__b' with check 'c' and a column 'a' with check 'b__c' both produce
                 # '__check__a__b__c'. Nothing parses these aliases; they are opaque handles.
-                alias = f"__check__{len(check_masks)}"
+                alias = f"__check__{check_index}"
+                check_index += 1
                 _reject_alias_collision(
                     alias,
                     current_columns,

--- a/src/nyctea/engine/phases.py
+++ b/src/nyctea/engine/phases.py
@@ -370,7 +370,7 @@ class ColumnCheckPhase(PipelinePhase):
                 continue
 
             for check_spec in checks_to_run:
-                if check_spec.name == COERCION_CHECK and (col_name, COERCION_CHECK) in check_masks:
+                if check_spec.name == COERCION_CHECK and schema.resolve_coerce(col_name):
                     raise PipelineError(
                         f"Column '{col_name}' has coercion enabled and also has a check named "
                         f"'{COERCION_CHECK}'. The name is reserved for the built-in coercion "

--- a/src/nyctea/engine/results.py
+++ b/src/nyctea/engine/results.py
@@ -71,14 +71,15 @@ class ValidationReport(BaseModel):
 
     def summary(self) -> str:
         """Return a human-readable summary of the validation report."""
+        pct = (self.rows_valid / self.rows_processed * 100) if self.rows_processed else 0.0
         lines = [
             f"Validation Report (on_failure: {self.on_failure})",
-            f"Rows: {self.rows_valid}/{self.rows_processed} valid ({self.rows_valid / self.rows_processed * 100:.1f}%)",
+            f"Rows: {self.rows_valid}/{self.rows_processed} valid ({pct:.1f}%)",
             "",
             "Column Issues:",
         ]
         for col_name, stats in self.columns.items():
-            if stats.nullified > 0 or stats.check_failures > 0:
+            if stats.nullified > 0 or stats.check_failures > 0 or stats.coercion_failures > 0:
                 lines.append(f"  {col_name}:")
                 if stats.coercion_failures:
                     lines.append(f"    Coercion failures: {stats.coercion_failures}")

--- a/src/nyctea/engine/validate.py
+++ b/src/nyctea/engine/validate.py
@@ -109,14 +109,15 @@ class ValidationReport(BaseModel):
 
     def summary(self) -> str:
         """Human-readable summary."""
+        pct = (self.rows_valid / self.rows_processed * 100) if self.rows_processed else 0.0
         lines = [
             f"Validation Report (on_failure: {self.on_failure})",
-            f"Rows: {self.rows_valid}/{self.rows_processed} valid ({self.rows_valid / self.rows_processed * 100:.1f}%)",
+            f"Rows: {self.rows_valid}/{self.rows_processed} valid ({pct:.1f}%)",
             "",
             "Column Issues:",
         ]
         for col_name, stats in self.columns.items():
-            if stats.nullified > 0 or stats.check_failures > 0:
+            if stats.nullified > 0 or stats.check_failures > 0 or stats.coercion_failures > 0:
                 lines.append(f"  {col_name}:")
                 if stats.coercion_failures:
                     lines.append(f"    Coercion failures: {stats.coercion_failures}")

--- a/src/nyctea/schema/validator.py
+++ b/src/nyctea/schema/validator.py
@@ -318,8 +318,11 @@ class SchemaValidator:
         exprs: list[pl.Expr] = [pl.len().alias("__total__")]
 
         for col_name, aliases in check_masks_by_col.items():
+            # Sum of per-check failure counts, not distinct failing rows, so this
+            # matches the totals in `errors` for the same column: a row failing two
+            # checks contributes two failures here, same as two rows in `errors`.
             exprs.append(
-                pl.any_horizontal([~pl.col(alias) for alias in aliases]).sum().alias(f"__check_fail__{col_name}")
+                pl.sum_horizontal([(~pl.col(alias)).sum() for alias in aliases]).alias(f"__check_fail__{col_name}")
             )
         exprs.extend(
             (~pl.col(alias)).sum().alias(f"__coercion_fail__{col_name}")

--- a/src/nyctea/schema/validator.py
+++ b/src/nyctea/schema/validator.py
@@ -10,9 +10,9 @@ import polars as pl
 
 from nyctea.engine.context import PipelineContext
 from nyctea.engine.factory import create_pipeline_from_schema
-from nyctea.engine.phases import NOT_NULL_CHECK
+from nyctea.engine.phases import COERCION_CHECK, NOT_NULL_CHECK
 from nyctea.engine.pipeline import ValidationPipeline
-from nyctea.engine.validate import ErrorReportConfig, ValidationReport, ValidationResult
+from nyctea.engine.validate import ColumnValidationStats, ErrorReportConfig, ValidationReport, ValidationResult
 from nyctea.exceptions import PipelineError
 from nyctea.schema.model import SchemaModel
 from nyctea.validators.registry import Registry
@@ -160,37 +160,30 @@ class SchemaValidator:
     def _enforce_coercion_raise(self, context: PipelineContext) -> None:
         """Raise PipelineError if on_failure=raise columns gained nulls from coercion.
 
-        Uses a targeted collect of only the new-null counts (1-row aggregation),
-        not the full data.
+        Uses a targeted collect of only the failure counts (1-row aggregation), not
+        the full data.
 
         Args:
-            context: Pipeline context with LazyFrame containing __pre_null__ masks.
+            context: Pipeline context with check_masks populated (CoercionPhase
+                registers one coercion mask per cast column).
 
         Raises:
             PipelineError: If any on_failure=raise column has coercion-introduced nulls.
         """
         schema = context.schema
-        lf = context.data
-        col_names = lf.collect_schema().names()
 
-        count_exprs: list[pl.Expr] = []
-        raise_cols: list[str] = []
-
-        for col_name in schema.columns:
-            pre_null_col = f"__pre_null__{col_name}"
-            if pre_null_col not in col_names:
-                continue
-            if schema.resolve_on_failure(col_name) != "raise":
-                continue
-
-            expr = (pl.col(col_name).is_null() & ~pl.col(pre_null_col)).sum().alias(f"__new_nulls__{col_name}")
-            count_exprs.append(expr)
-            raise_cols.append(col_name)
-
-        if not count_exprs:
+        raise_cols = {
+            col_name: alias
+            for (col_name, check_name), alias in context.check_masks.items()
+            if check_name == COERCION_CHECK and schema.resolve_on_failure(col_name) == "raise"
+        }
+        if not raise_cols:
             return
 
-        counts = _collect(lf.select(count_exprs))
+        count_exprs = [
+            (~pl.col(alias)).sum().alias(f"__new_nulls__{col_name}") for col_name, alias in raise_cols.items()
+        ]
+        counts = _collect(context.data.select(count_exprs))
         for col_name in raise_cols:
             new_nulls = int(counts[f"__new_nulls__{col_name}"].item())
             if new_nulls > 0:
@@ -210,6 +203,10 @@ class SchemaValidator:
         rewrites ``'null'`` to ``'raise'`` for non-nullable columns; ``'ignore'`` is
         unaffected and can still apply).
 
+        Also excludes the coercion check: it has its own raise path, and a
+        coercion-failed value is already null, so nulling it again here would
+        double-count it in ``nullified_counts``.
+
         Args:
             context: Pipeline context with populated check_masks.
             on_failure: The resolved on_failure behavior to filter columns by.
@@ -220,7 +217,7 @@ class SchemaValidator:
         schema = context.schema
         grouped: dict[str, list[str]] = {}
         for (col_name, check_name), alias in context.check_masks.items():
-            if check_name == NOT_NULL_CHECK:
+            if check_name in (NOT_NULL_CHECK, COERCION_CHECK):
                 continue
             if schema.resolve_on_failure(col_name) != on_failure:
                 continue
@@ -293,13 +290,71 @@ class SchemaValidator:
         context.data = context.data.with_columns(null_exprs)
 
     def _build_report(self, context: PipelineContext) -> ValidationReport:
-        """Stub — row counts only. Replaced by ReportGenerationPhase (Step 4)."""
-        total = int(_collect(context.data.select(pl.len())).item())
+        """Build the validation report from the same check masks used by ``_build_errors``.
+
+        Coercion failures get their own column stat but still count toward rows_failed.
+
+        Uses a single targeted collect of per-column/per-row aggregations, never the
+        full data.
+
+        Args:
+            context: Pipeline context with check_masks and nullified_counts populated.
+
+        Returns:
+            ValidationReport with row counts and per-column statistics.
+        """
+        schema = context.schema
+        lf = context.data
+        col_names = lf.collect_schema().names()
+
+        check_masks_by_col: dict[str, list[str]] = {}
+        coercion_alias_by_col: dict[str, str] = {}
+        for (col_name, check_name), alias in context.check_masks.items():
+            if check_name == COERCION_CHECK:
+                coercion_alias_by_col[col_name] = alias
+            else:
+                check_masks_by_col.setdefault(col_name, []).append(alias)
+
+        exprs: list[pl.Expr] = [pl.len().alias("__total__")]
+
+        for col_name, aliases in check_masks_by_col.items():
+            exprs.append(
+                pl.any_horizontal([~pl.col(alias) for alias in aliases]).sum().alias(f"__check_fail__{col_name}")
+            )
+        exprs.extend(
+            (~pl.col(alias)).sum().alias(f"__coercion_fail__{col_name}")
+            for col_name, alias in coercion_alias_by_col.items()
+        )
+
+        if context.check_masks:
+            all_aliases = list(context.check_masks.values())
+            exprs.append(pl.any_horizontal([~pl.col(alias) for alias in all_aliases]).sum().alias("__rows_failed__"))
+
+        report_cols = [c for c in schema.columns if c in col_names]
+        exprs.extend(pl.col(col_name).is_null().sum().alias(f"__final_null__{col_name}") for col_name in report_cols)
+
+        row = _collect(lf.select(exprs))
+
+        total = int(row["__total__"].item())
+        rows_failed = int(row["__rows_failed__"].item()) if "__rows_failed__" in row.columns else 0
+
+        columns: dict[str, ColumnValidationStats] = {}
+        for col_name in report_cols:
+            check_fail_alias = f"__check_fail__{col_name}"
+            coercion_fail_alias = f"__coercion_fail__{col_name}"
+            columns[col_name] = ColumnValidationStats(
+                column_name=col_name,
+                coercion_failures=int(row[coercion_fail_alias].item()) if coercion_fail_alias in row.columns else 0,
+                check_failures=int(row[check_fail_alias].item()) if check_fail_alias in row.columns else 0,
+                nullified=context.nullified_counts.get(col_name, 0),
+                final_null_count=int(row[f"__final_null__{col_name}"].item()),
+            )
+
         return ValidationReport(
             rows_processed=total,
-            rows_valid=total,
-            on_failure=context.schema.on_failure,
-            columns={},
+            rows_valid=total - rows_failed,
+            on_failure=schema.on_failure,
+            columns=columns,
         )
 
     def _build_errors(self, context: PipelineContext) -> pl.DataFrame:

--- a/tests/engine/test_phases.py
+++ b/tests/engine/test_phases.py
@@ -665,6 +665,25 @@ class TestNullification:
         with pytest.raises(PipelineError, match="reserved"):
             schema.validate(pl.DataFrame({"age": ["1", "2"]}), registry)
 
+    def test_coercion_check_name_is_reserved_even_when_no_cast_is_needed(self, registry):
+        """The reservation is a schema property, not conditional on this input needing a cast."""
+        decorators = ValidatorDecorator(registry)
+
+        @decorators.column_check(name="coerce", tags=[])
+        def fake_coerce(column: pl.Expr) -> pl.Expr:
+            return column > 0
+
+        schema = SchemaModel.from_dict(
+            {
+                "coerce": True,
+                "columns": {
+                    "age": {"dtype": "Int64", "nullable": True, "checks": [{"name": "coerce"}]},
+                },
+            }
+        )
+        with pytest.raises(PipelineError, match="reserved"):
+            schema.validate(pl.DataFrame({"age": [1, 2]}), registry)
+
 
 # ---------------------------------------------------------------------------
 # Error report modes

--- a/tests/engine/test_phases.py
+++ b/tests/engine/test_phases.py
@@ -504,6 +504,34 @@ class TestFullPipeline:
         result = schema.validate(df, registry)
         assert result.report.columns["score"].check_failures == 2
 
+    def test_check_failures_sum_matches_errors_with_multiple_checks(self, registry):
+        """A row failing two checks on the same column must count as two failures.
+
+        report.columns[col].check_failures must equal the sum of errors["count"]
+        for that column, not the count of distinct failing rows.
+        """
+        schema = SchemaModel.from_dict(
+            {
+                "on_failure": "ignore",
+                "columns": {
+                    "age": {
+                        "dtype": "Int64",
+                        "nullable": True,
+                        "checks": [
+                            {"name": "min_value", "args": {"min": 0}},
+                            {"name": "between", "args": {"min": 0, "max": 100}},
+                        ],
+                    },
+                },
+            }
+        )
+        df = pl.DataFrame({"age": [50, -1, 200]})
+        result = schema.validate(df, registry)
+        errors_sum = result.errors.filter(pl.col("column") == "age")["count"].sum()
+        assert errors_sum == 3
+        assert result.report.columns["age"].check_failures == errors_sum
+        assert result.report.rows_valid == 1
+
     def test_coerce_strict_incompatible_type_raises(self, registry):
         schema = SchemaModel.from_dict(
             {

--- a/tests/engine/test_phases.py
+++ b/tests/engine/test_phases.py
@@ -8,6 +8,8 @@ import pytest
 from nyctea import Registry, SchemaModel, register_builtins
 from nyctea.engine.context import PipelineContext
 from nyctea.engine.phases import (
+    COERCION_CHECK,
+    NOT_NULL_CHECK,
     CoercionPhase,
 )
 from nyctea.engine.results import ErrorReportConfig
@@ -102,6 +104,19 @@ class TestResolveDtype:
     def test_unsupported_type_raises(self):
         with pytest.raises(ValueError, match="Unsupported dtype specification"):
             _resolve_dtype(123)
+
+
+# ---------------------------------------------------------------------------
+# Public check-name contract
+# ---------------------------------------------------------------------------
+
+
+class TestPublicCheckNameContract:
+    def test_not_null_check_name_is_frozen(self):
+        assert NOT_NULL_CHECK == "not_null"
+
+    def test_coercion_check_name_is_frozen(self):
+        assert COERCION_CHECK == "coerce"
 
 
 # ---------------------------------------------------------------------------
@@ -245,7 +260,6 @@ class TestFullPipeline:
         assert result.report.rows_valid == 3
         assert len(result.errors) == 0
 
-    @pytest.mark.skip(reason="Step 4: _build_report() stub returns empty columns")
     def test_check_failure_recorded(self, registry):
         schema = SchemaModel.from_dict(
             {
@@ -253,6 +267,7 @@ class TestFullPipeline:
                     "age": {
                         "dtype": "Int64",
                         "nullable": True,
+                        "on_failure": "ignore",
                         "checks": [{"name": "between", "args": {"min": 0, "max": 150}}],
                     },
                 }
@@ -408,6 +423,29 @@ class TestFullPipeline:
         with pytest.raises(PipelineError, match="already contains a column named"):
             schema.validate(df, registry)
 
+    def test_check_mask_alias_collision_raises_with_coercion_active(self, registry):
+        """A pre-seeded coercion mask must not shift the check-mask alias counter.
+
+        Otherwise the first real check gets '__check__1' instead of '__check__0',
+        and a user column literally named '__check__0' slips past this guard.
+        """
+        schema = SchemaModel.from_dict(
+            {
+                "coerce": True,
+                "columns": {
+                    "age": {
+                        "dtype": "Int64",
+                        "nullable": True,
+                        "checks": [{"name": "min_value", "args": {"min": 0}}],
+                    },
+                    "__check__0": {"dtype": "Int64", "nullable": True},
+                },
+            }
+        )
+        df = pl.DataFrame({"age": ["1", "2"], "__check__0": [9, 9]})
+        with pytest.raises(PipelineError, match="already contains a column named"):
+            schema.validate(df, registry)
+
     def test_check_mask_aliases_are_unambiguous(self, registry):
         """Column and check names containing '__' must not produce a shared alias.
 
@@ -449,7 +487,6 @@ class TestFullPipeline:
         result = schema.validate(df, registry)
         assert "age" in result.data.collect_schema().names()
 
-    @pytest.mark.skip(reason="Step 4: _build_report() stub returns empty columns")
     def test_report_check_failure_counts(self, registry):
         schema = SchemaModel.from_dict(
             {
@@ -457,6 +494,7 @@ class TestFullPipeline:
                     "score": {
                         "dtype": "Int64",
                         "nullable": True,
+                        "on_failure": "ignore",
                         "checks": [{"name": "min_value", "args": {"min": 0}}],
                     },
                 }
@@ -497,7 +535,6 @@ class TestFullPipeline:
 
 
 class TestNullification:
-    @pytest.mark.skip(reason="Step 5: NullificationPhase not yet implemented")
     def test_failing_values_nullified(self, registry):
         schema = SchemaModel.from_dict(
             {
@@ -519,6 +556,114 @@ class TestNullification:
         assert ages[0] == 10
         assert ages[2] == 5
         assert result.report.columns["age"].nullified == 2
+
+    def test_check_nullified_values_not_counted_as_coercion_failures(self, registry):
+        """A value nulled by a failing check must not also be reported as a coercion failure.
+
+        Both look identical from the __pre_null__ snapshot alone (wasn't null before
+        coercion, is null now), so the report must distinguish them.
+        """
+        schema = SchemaModel.from_dict(
+            {
+                "coerce": True,
+                "on_failure": "null",
+                "columns": {
+                    "age": {
+                        "dtype": "Int64",
+                        "nullable": True,
+                        "checks": [{"name": "min_value", "args": {"min": 0}}],
+                    }
+                },
+            }
+        )
+        df = pl.DataFrame({"age": ["10", "-1", "20"]})
+        result = schema.validate(df, registry)
+        assert result.report.columns["age"].coercion_failures == 0
+        assert result.report.columns["age"].nullified == 1
+
+    def test_coercion_failures_are_reported(self, registry):
+        schema = SchemaModel.from_dict(
+            {
+                "coerce": True,
+                "on_failure": "ignore",
+                "columns": {"age": {"dtype": "Int64", "nullable": True}},
+            }
+        )
+        df = pl.DataFrame({"age": ["10", "bad", "20"]})
+        result = schema.validate(df, registry)
+        assert result.report.columns["age"].coercion_failures == 1
+        assert "Coercion failures: 1" in result.report.summary()
+
+    def test_coercion_failures_appear_in_errors(self, registry):
+        """Coercion failures follow the same reporting path as parser/check failures."""
+        schema = SchemaModel.from_dict(
+            {
+                "coerce": True,
+                "on_failure": "ignore",
+                "columns": {"age": {"dtype": "Int64", "nullable": True}},
+            }
+        )
+        df = pl.DataFrame({"age": ["10", "bad", "20"]})
+        result = schema.validate(df, registry)
+        assert result.errors.filter((pl.col("column") == "age") & (pl.col("check") == "coerce"))["count"].item() == 1
+
+    def test_coercion_failures_reduce_rows_valid(self, registry):
+        schema = SchemaModel.from_dict(
+            {
+                "coerce": True,
+                "on_failure": "ignore",
+                "columns": {"age": {"dtype": "Int64", "nullable": True}},
+            }
+        )
+        df = pl.DataFrame({"age": ["10", "bad", "20"]})
+        result = schema.validate(df, registry)
+        assert result.report.rows_processed == 3
+        assert result.report.rows_valid == 2
+
+    def test_coercion_raise_is_strict_by_default(self, registry):
+        """Default on_failure='raise' stops before checks ever run on the coerced garbage."""
+        schema = SchemaModel.from_dict({"coerce": True, "columns": {"age": {"dtype": "Int64", "nullable": True}}})
+        df = pl.DataFrame({"age": ["10", "bad", "20"]})
+        with pytest.raises(PipelineError, match="Coercion failed for column 'age'"):
+            schema.validate(df, registry)
+
+    def test_coercion_failure_on_non_nullable_column_reports_both_and_counts_once(self, registry):
+        """A coercion-failed cell on a nullable=False column is null: both constraints fail.
+
+        Both should be reported, but the row must only count as invalid once.
+        """
+        schema = SchemaModel.from_dict(
+            {
+                "coerce": True,
+                "on_failure": "ignore",
+                "columns": {"age": {"dtype": "Int64", "nullable": False}},
+            }
+        )
+        df = pl.DataFrame({"age": ["10", "bad", "20"]})
+        result = schema.validate(df, registry)
+        assert result.report.rows_processed == 3
+        assert result.report.rows_valid == 2
+        assert result.errors.filter((pl.col("column") == "age") & (pl.col("check") == "coerce"))["count"].item() == 1
+        assert result.errors.filter((pl.col("column") == "age") & (pl.col("check") == "not_null"))["count"].item() == 1
+
+    def test_coercion_check_name_is_reserved(self, registry):
+        """A user check named 'coerce' on a coerced column must not silently collide."""
+        decorators = ValidatorDecorator(registry)
+
+        @decorators.column_check(name="coerce", tags=[])
+        def fake_coerce(column: pl.Expr) -> pl.Expr:
+            return column > 0
+
+        schema = SchemaModel.from_dict(
+            {
+                "coerce": True,
+                "columns": {
+                    "age": {"dtype": "Int64", "nullable": True, "checks": [{"name": "coerce"}]},
+                },
+            }
+        )
+        with pytest.raises(PipelineError, match="reserved"):
+            schema.validate(pl.DataFrame({"age": ["1", "2"]}), registry)
 
 
 # ---------------------------------------------------------------------------
@@ -672,7 +817,6 @@ class TestErrorReporting:
 
 
 class TestValidationReportSummary:
-    @pytest.mark.skip(reason="Step 4: _build_report() stub returns empty columns")
     def test_summary_with_failures(self, registry):
         schema = SchemaModel.from_dict(
             {
@@ -698,6 +842,13 @@ class TestValidationReportSummary:
         result = schema.validate(df, registry)
         text = result.report.summary()
         assert "3/3 valid" in text
+
+    def test_summary_empty_frame_does_not_divide_by_zero(self, registry):
+        schema = SchemaModel.from_dict({"columns": {"age": {"dtype": "Int64", "nullable": True}}})
+        df = pl.DataFrame({"age": []}, schema={"age": pl.Int64})
+        result = schema.validate(df, registry)
+        text = result.report.summary()
+        assert "0/0 valid (0.0%)" in text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/engine/test_results.py
+++ b/tests/engine/test_results.py
@@ -1,0 +1,23 @@
+"""Tests for the duplicate result types in engine/results.py.
+
+Not part of the public API (nyctea/__init__.py exports ValidationReport from
+engine/validate.py instead), but the class is a near-identical copy with the same
+bugs, so it needs its own coverage until #12 removes the duplication.
+"""
+
+from nyctea.engine.results import ColumnValidationStats, ValidationReport
+
+
+def test_summary_empty_frame_does_not_divide_by_zero():
+    report = ValidationReport(rows_processed=0, rows_valid=0, on_failure="raise")
+    assert "0/0 valid (0.0%)" in report.summary()
+
+
+def test_summary_reports_coercion_only_failures():
+    report = ValidationReport(
+        rows_processed=3,
+        rows_valid=2,
+        on_failure="ignore",
+        columns={"age": ColumnValidationStats(column_name="age", coercion_failures=1)},
+    )
+    assert "Coercion failures: 1" in report.summary()


### PR DESCRIPTION
This pull request introduces comprehensive support for tracking and reporting coercion (dtype cast) failures during schema validation, alongside several improvements to validation reporting and test coverage. The changes ensure that coercion failures are handled distinctly from other check failures, are correctly reported in summaries, and that reserved check names are enforced to prevent user collisions. The documentation and tests have also been updated to reflect these enhancements.

**Coercion Failure Tracking and Reporting**

* Added a dedicated mask and reserved check name (`"coerce"`) for tracking coercion failures in `CoercionPhase`, ensuring that dtype cast failures are counted and reported per column. [[1]](diffhunk://#diff-611d6e757c94d12e15c6e4b8e608eb2180ff13b0a0d7d5cafa6477ec1286d5ceL20-R23) [[2]](diffhunk://#diff-611d6e757c94d12e15c6e4b8e608eb2180ff13b0a0d7d5cafa6477ec1286d5ceR294-R308) [[3]](diffhunk://#diff-611d6e757c94d12e15c6e4b8e608eb2180ff13b0a0d7d5cafa6477ec1286d5ceL346-R364) [[4]](diffhunk://#diff-611d6e757c94d12e15c6e4b8e608eb2180ff13b0a0d7d5cafa6477ec1286d5ceR373-R380) [[5]](diffhunk://#diff-611d6e757c94d12e15c6e4b8e608eb2180ff13b0a0d7d5cafa6477ec1286d5ceL377-R403)
* Updated the validation report generation to include coercion failures in per-column statistics and overall row validity calculations. [[1]](diffhunk://#diff-04be3d8f9465cc00ca9ce7120dd81281508fff1b975aa58ba3fa51672c0448e9L296-R357) [[2]](diffhunk://#diff-70e477497899a4481ca8d6b3237d944dcb5facbdb2b2a2e08121c94fc6a026cdR74-R82) [[3]](diffhunk://#diff-53d03c9ef66331b96805bffdba3948e8aca229b56db9c715debc52d8b3ae6540R112-R120)

**Validation Logic and Error Handling**

* Modified enforcement logic to use the new coercion masks for raising errors when `on_failure="raise"` is set, ensuring coercion failures are handled separately from nullification. [[1]](diffhunk://#diff-04be3d8f9465cc00ca9ce7120dd81281508fff1b975aa58ba3fa51672c0448e9L163-R186) [[2]](diffhunk://#diff-04be3d8f9465cc00ca9ce7120dd81281508fff1b975aa58ba3fa51672c0448e9R206-R209) [[3]](diffhunk://#diff-04be3d8f9465cc00ca9ce7120dd81281508fff1b975aa58ba3fa51672c0448e9L223-R220)
* Improved alias collision handling for check masks, especially when coercion masks are present, to prevent user columns from conflicting with internal mask names. [[1]](diffhunk://#diff-611d6e757c94d12e15c6e4b8e608eb2180ff13b0a0d7d5cafa6477ec1286d5ceL377-R403) [[2]](diffhunk://#diff-cbed9af2ba967040ecf4a4f3d21714b5e951a574b1ee612baa2152321443db2bR426-R448)

**Documentation and User Guide Updates**

* Updated the quickstart documentation to clarify the effect of `on_failure: ignore` for nulls and to show correct reporting of check failures and coercion outcomes. [[1]](diffhunk://#diff-e6575a20fd3a5325b9ad350ff206f0eb83dbe4db9122bb08161362dd59c2a2e1R40-R44) [[2]](diffhunk://#diff-e6575a20fd3a5325b9ad350ff206f0eb83dbe4db9122bb08161362dd59c2a2e1L64-R70) [[3]](diffhunk://#diff-e6575a20fd3a5325b9ad350ff206f0eb83dbe4db9122bb08161362dd59c2a2e1L80-R81) [[4]](diffhunk://#diff-e6575a20fd3a5325b9ad350ff206f0eb83dbe4db9122bb08161362dd59c2a2e1L99-R100)

**Test Coverage Enhancements**

* Added tests to verify that reserved check names (`"not_null"`, `"coerce"`) are enforced and that coercion mask aliasing does not interfere with user data. [[1]](diffhunk://#diff-cbed9af2ba967040ecf4a4f3d21714b5e951a574b1ee612baa2152321443db2bR11-R12) [[2]](diffhunk://#diff-cbed9af2ba967040ecf4a4f3d21714b5e951a574b1ee612baa2152321443db2bR109-R121) [[3]](diffhunk://#diff-cbed9af2ba967040ecf4a4f3d21714b5e951a574b1ee612baa2152321443db2bR426-R448)
* Enabled and updated tests to check that check failure counts and coercion failures are correctly reported in validation results. [[1]](diffhunk://#diff-cbed9af2ba967040ecf4a4f3d21714b5e951a574b1ee612baa2152321443db2bL248-R270) [[2]](diffhunk://#diff-cbed9af2ba967040ecf4a4f3d21714b5e951a574b1ee612baa2152321443db2bL452-R497) [[3]](diffhunk://#diff-cbed9af2ba967040ecf4a4f3d21714b5e951a574b1ee612baa2152321443db2bL500)

**Internal Refactoring**

* Refactored how check masks and per-column statistics are aggregated and reported, improving maintainability and accuracy. [[1]](diffhunk://#diff-04be3d8f9465cc00ca9ce7120dd81281508fff1b975aa58ba3fa51672c0448e9L296-R357) [[2]](diffhunk://#diff-04be3d8f9465cc00ca9ce7120dd81281508fff1b975aa58ba3fa51672c0448e9L163-R186)

These changes collectively make coercion failures first-class citizens in the validation process and improve the clarity and reliability of validation feedback for users.