### PR TITLE
frame parsing + checking phase added + pipeline extended

### DIFF
--- a/docs/development/decisions/adr-pipeline-design.md
+++ b/docs/development/decisions/adr-pipeline-design.md
@@ -87,10 +87,10 @@ The monolith is removed once all phases below are implemented and integration te
 |-----------------------------|------------------------------|
 | `resolve_column_names`      | `ColumnResolutionPhase` ✅   |
 | `_count_original_nulls`     | tracked in context            |
-| `_apply_frame_parsers`      | `FrameParserPhase` (todo)    |
+| `_apply_frame_parsers`      | `FrameParsingPhase` ✅       |
 | `_apply_column_parsers`     | `ColumnParsingPhase` ✅      |
 | `_apply_coercion`           | `CoercionPhase` (todo)       |
-| `_apply_frame_checks`       | `FrameCheckPhase` (todo)     |
+| `_apply_frame_checks`       | `FrameCheckPhase` ✅         |
 | `_collect_column_checks`    | `ColumnCheckPhase` ✅ (partial) |
 | `_build_error_report`       | `ErrorReportingPhase` (todo) |
 | `_apply_lenient_checks`     | `NullificationPhase` (todo)  |

--- a/docs/development/decisions/adr-pipeline-design.md
+++ b/docs/development/decisions/adr-pipeline-design.md
@@ -89,7 +89,7 @@ The monolith is removed once all phases below are implemented and integration te
 | `_count_original_nulls`     | tracked in context            |
 | `_apply_frame_parsers`      | `FrameParsingPhase` ✅       |
 | `_apply_column_parsers`     | `ColumnParsingPhase` ✅      |
-| `_apply_coercion`           | `CoercionPhase` (todo)       |
+| `_apply_coercion`           | `CoercionPhase` ✅           |
 | `_apply_frame_checks`       | `FrameCheckPhase` ✅         |
 | `_collect_column_checks`    | `ColumnCheckPhase` ✅ (partial) |
 | `_build_error_report`       | `ErrorReportingPhase` (todo) |

--- a/docs/user-guide/features.md
+++ b/docs/user-guide/features.md
@@ -77,6 +77,33 @@ schema = SchemaModel.from_dict({
 })
 ```
 
+## Frame-level parsers and checks
+
+Column parsers and checks operate on one column at a time. Frame parsers and checks
+operate on the whole DataFrame, for rules that need to see more than one column, such
+as cross-column comparisons or a minimum row count.
+
+```python
+from nyctea.validators.decorators import ValidatorDecorator
+
+decorators = ValidatorDecorator(registry)
+
+@decorators.frame_check(name="min_rows")
+def min_rows(frame: pl.LazyFrame, min_rows: int = 1) -> pl.LazyFrame:
+    if frame.select(pl.len()).collect().item() < min_rows:
+        raise ValueError(f"expected at least {min_rows} rows")
+    return frame
+
+schema = SchemaModel.from_dict({
+    "frame_checks": [{"name": "min_rows", "args": {"min_rows": 2}}],
+    "columns": {"age": {"dtype": "Int64"}},
+})
+```
+
+Frame checks must return the frame unchanged (same rows, same columns) and raise on
+failure. Frame parsers may add, drop, or reorder columns and rows, and run before
+column parsers so later steps see the transformed frame.
+
 ## Failure handling
 
 The `on_failure` field controls what happens when validation fails. Set it at schema level or per column.

--- a/docs/user-guide/features.md
+++ b/docs/user-guide/features.md
@@ -100,9 +100,11 @@ schema = SchemaModel.from_dict({
 })
 ```
 
-Frame checks must return the frame unchanged (same rows, same columns) and raise on
-failure. Frame parsers may add, drop, or reorder columns and rows, and run before
-column parsers so later steps see the transformed frame.
+Frame checks must preserve row count and the set of columns, and raise on failure.
+Column order and values are not checked, so a well-behaved frame check should not
+change them even though nothing currently enforces it. Frame parsers may add, drop,
+or reorder columns and rows, and run before column parsers so later steps see the
+transformed frame.
 
 ## Failure handling
 

--- a/src/nyctea/engine/factory.py
+++ b/src/nyctea/engine/factory.py
@@ -12,6 +12,8 @@ from nyctea.engine.phases import (
     ColumnCheckPhase,
     ColumnParsingPhase,
     ColumnResolutionPhase,
+    FrameCheckPhase,
+    FrameParsingPhase,
 )
 from nyctea.engine.pipeline import ValidationPipeline
 from nyctea.schema.model import SchemaModel
@@ -102,6 +104,9 @@ def create_pipeline_from_schema(
     # Column resolution is always required
     phases.append(ColumnResolutionPhase())
 
+    if schema.frame_parsers:
+        phases.append(FrameParsingPhase())
+
     # Add parsing phase if any column has parsers
     has_parsers = any(col_schema.parsers for col_schema in schema.columns.values())
     if has_parsers:
@@ -109,6 +114,9 @@ def create_pipeline_from_schema(
 
     # Coercion always present (can_skip handles coerce=False)
     phases.append(CoercionPhase())
+
+    if schema.frame_checks:
+        phases.append(FrameCheckPhase())
 
     # Add check phase if any column has checks or nullable=False
     has_checks = any(col_schema.checks or not col_schema.nullable for col_schema in schema.columns.values())

--- a/src/nyctea/engine/phases.py
+++ b/src/nyctea/engine/phases.py
@@ -48,6 +48,8 @@ __all__ = [
     "ColumnCheckPhase",
     "ColumnParsingPhase",
     "ColumnResolutionPhase",
+    "FrameCheckPhase",
+    "FrameParsingPhase",
 ]
 
 
@@ -133,6 +135,71 @@ class ColumnResolutionPhase(PipelinePhase):
             context.data = lf.rename(mapping)
 
         return context
+
+
+class FrameParsingPhase(PipelinePhase):
+    """Apply frame-level parsers (whole-DataFrame transformations).
+
+    Runs before column parsing, so frame parsers see the data first (they may
+    add/drop rows or columns other parsers then operate on).
+
+    Dependencies: column_resolution
+    """
+
+    def __init__(self) -> None:
+        """Initialize frame parsing phase."""
+        super().__init__(
+            name="frame_parsing",
+            phase_type=PhaseType.PARSING,
+            dependencies=["column_resolution"],
+        )
+
+    def execute(self, context: PipelineContext) -> PipelineContext:
+        """Apply frame parsers in schema-declared order.
+
+        Args:
+            context: Pipeline context.
+
+        Returns:
+            Updated context with the frame parsers applied.
+
+        Raises:
+            PipelineError: If a frame parser is unregistered or fails.
+        """
+        registry = context.registry
+        lf = context.data
+
+        for parser_spec in context.schema.frame_parsers:
+            try:
+                parser = registry.frame_parsers.get(parser_spec.name)
+            except KeyError as e:
+                raise PipelineError(
+                    f"Frame parser '{parser_spec.name}' not found in registry. "
+                    f"Available: {registry.frame_parsers.list_names()}",
+                    phase=self.name,
+                ) from e
+
+            try:
+                lf = parser(lf, **parser_spec.args)
+            except Exception as e:
+                raise PipelineError(
+                    f"Frame parser '{parser_spec.name}' failed: {e}",
+                    phase=self.name,
+                ) from e
+
+        context.data = lf
+        return context
+
+    def can_skip(self, context: PipelineContext) -> bool:
+        """Skip if the schema defines no frame parsers.
+
+        Args:
+            context: Pipeline context.
+
+        Returns:
+            True if no frame parsers are defined.
+        """
+        return not context.schema.frame_parsers
 
 
 class ColumnParsingPhase(PipelinePhase):
@@ -318,6 +385,72 @@ class CoercionPhase(PipelinePhase):
             True if no column will be coerced.
         """
         return not any(context.schema.resolve_coerce(col_name) for col_name in context.schema.columns)
+
+
+class FrameCheckPhase(PipelinePhase):
+    """Apply frame-level checks (whole-DataFrame validations).
+
+    Runs after coercion so frame checks see typed data, and before column
+    checks. A ``FrameCheck`` always preserves rows and columns (enforced by
+    the base class), so it can only pass a frame through or raise.
+
+    Dependencies: coercion
+    """
+
+    def __init__(self) -> None:
+        """Initialize frame check phase."""
+        super().__init__(
+            name="frame_checks",
+            phase_type=PhaseType.CHECKING,
+            dependencies=["coercion"],
+        )
+
+    def execute(self, context: PipelineContext) -> PipelineContext:
+        """Apply frame checks in schema-declared order.
+
+        Args:
+            context: Pipeline context.
+
+        Returns:
+            Updated context with the frame checks applied.
+
+        Raises:
+            PipelineError: If a frame check is unregistered or fails.
+        """
+        registry = context.registry
+        lf = context.data
+
+        for check_spec in context.schema.frame_checks:
+            try:
+                check = registry.frame_checks.get(check_spec.name)
+            except KeyError as e:
+                raise PipelineError(
+                    f"Frame check '{check_spec.name}' not found in registry. "
+                    f"Available: {registry.frame_checks.list_names()}",
+                    phase=self.name,
+                ) from e
+
+            try:
+                lf = check(lf, **check_spec.args)
+            except Exception as e:
+                raise PipelineError(
+                    f"Frame check '{check_spec.name}' failed: {e}",
+                    phase=self.name,
+                ) from e
+
+        context.data = lf
+        return context
+
+    def can_skip(self, context: PipelineContext) -> bool:
+        """Skip if the schema defines no frame checks.
+
+        Args:
+            context: Pipeline context.
+
+        Returns:
+            True if no frame checks are defined.
+        """
+        return not context.schema.frame_checks
 
 
 class ColumnCheckPhase(PipelinePhase):

--- a/src/nyctea/engine/phases.py
+++ b/src/nyctea/engine/phases.py
@@ -391,8 +391,9 @@ class FrameCheckPhase(PipelinePhase):
     """Apply frame-level checks (whole-DataFrame validations).
 
     Runs after coercion so frame checks see typed data, and before column
-    checks. A ``FrameCheck`` always preserves rows and columns (enforced by
-    the base class), so it can only pass a frame through or raise.
+    checks. The base class only enforces row count and column set on a
+    ``FrameCheck``'s output, not order or values, so it should pass the frame
+    through unchanged or raise, though nothing currently enforces the former.
 
     Dependencies: coercion
     """

--- a/tests/engine/test_factory.py
+++ b/tests/engine/test_factory.py
@@ -1,0 +1,36 @@
+"""Tests for create_pipeline_from_schema's phase selection and ordering."""
+
+from nyctea.engine.factory import create_pipeline_from_schema
+from nyctea.schema.model import SchemaModel
+
+
+def _phase_names(schema_dict):
+    schema = SchemaModel.from_dict(schema_dict)
+    pipeline = create_pipeline_from_schema(schema)
+    return [phase.name for phase in pipeline.phases]
+
+
+def test_no_frame_phases_when_schema_has_none():
+    names = _phase_names({"columns": {"a": {"dtype": "Int64"}}})
+    assert "frame_parsing" not in names
+    assert "frame_checks" not in names
+
+
+def test_frame_parsing_phase_included_and_ordered_before_column_parsing():
+    names = _phase_names(
+        {
+            "frame_parsers": [{"name": "whatever"}],
+            "columns": {"a": {"dtype": "Int64", "parsers": [{"name": "strip"}]}},
+        }
+    )
+    assert names.index("frame_parsing") < names.index("column_parsing")
+
+
+def test_frame_check_phase_included_and_ordered_between_coercion_and_column_checks():
+    names = _phase_names(
+        {
+            "frame_checks": [{"name": "whatever"}],
+            "columns": {"a": {"dtype": "Int64", "nullable": False}},
+        }
+    )
+    assert names.index("coercion") < names.index("frame_checks") < names.index("column_checks")

--- a/tests/engine/test_phases.py
+++ b/tests/engine/test_phases.py
@@ -590,6 +590,22 @@ class TestFrameValidators:
         with pytest.raises(PipelineError, match="not found in registry"):
             schema.validate(pl.DataFrame({"a": [1]}), registry)
 
+    def test_frame_parser_execution_failure_raises(self, registry):
+        decorators = ValidatorDecorator(registry)
+
+        @decorators.frame_parser(name="explode", preserve_columns=False)
+        def explode(frame: pl.LazyFrame) -> pl.LazyFrame:  # noqa: ARG001
+            raise ValueError("boom")
+
+        schema = SchemaModel.from_dict(
+            {
+                "frame_parsers": [{"name": "explode"}],
+                "columns": {"a": {"dtype": "Int64"}},
+            }
+        )
+        with pytest.raises(PipelineError, match="boom"):
+            schema.validate(pl.DataFrame({"a": [1]}), registry)
+
     def test_frame_check_raises_on_failure(self, registry):
         decorators = ValidatorDecorator(registry)
 

--- a/tests/engine/test_phases.py
+++ b/tests/engine/test_phases.py
@@ -558,6 +558,87 @@ class TestFullPipeline:
 
 
 # ---------------------------------------------------------------------------
+# Frame-level parsers/checks (#8)
+# ---------------------------------------------------------------------------
+
+
+class TestFrameValidators:
+    def test_frame_parser_runs_and_transforms_data(self, registry):
+        decorators = ValidatorDecorator(registry)
+
+        @decorators.frame_parser(name="add_total", preserve_columns=False, preserve_rows=True)
+        def add_total(frame: pl.LazyFrame) -> pl.LazyFrame:
+            return frame.with_columns((pl.col("a") + pl.col("b")).alias("total"))
+
+        schema = SchemaModel.from_dict(
+            {
+                "frame_parsers": [{"name": "add_total"}],
+                "columns": {"a": {"dtype": "Int64"}, "b": {"dtype": "Int64"}},
+            }
+        )
+        df = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
+        result = schema.validate(df, registry)
+        assert result.data.collect()["total"].to_list() == [4, 6]
+
+    def test_frame_parser_not_registered_raises(self, registry):
+        schema = SchemaModel.from_dict(
+            {
+                "frame_parsers": [{"name": "does_not_exist"}],
+                "columns": {"a": {"dtype": "Int64"}},
+            }
+        )
+        with pytest.raises(PipelineError, match="not found in registry"):
+            schema.validate(pl.DataFrame({"a": [1]}), registry)
+
+    def test_frame_check_raises_on_failure(self, registry):
+        decorators = ValidatorDecorator(registry)
+
+        @decorators.frame_check(name="min_rows")
+        def min_rows(frame: pl.LazyFrame, min_rows: int = 1) -> pl.LazyFrame:
+            if frame.select(pl.len()).collect().item() < min_rows:
+                raise ValueError("not enough rows")
+            return frame
+
+        schema = SchemaModel.from_dict(
+            {
+                "frame_checks": [{"name": "min_rows", "args": {"min_rows": 5}}],
+                "columns": {"a": {"dtype": "Int64"}},
+            }
+        )
+        with pytest.raises(PipelineError, match="not enough rows"):
+            schema.validate(pl.DataFrame({"a": [1, 2]}), registry)
+
+    def test_frame_check_passes_through_on_success(self, registry):
+        decorators = ValidatorDecorator(registry)
+
+        @decorators.frame_check(name="min_rows")
+        def min_rows(frame: pl.LazyFrame, min_rows: int = 1) -> pl.LazyFrame:
+            if frame.select(pl.len()).collect().item() < min_rows:
+                raise ValueError("not enough rows")
+            return frame
+
+        schema = SchemaModel.from_dict(
+            {
+                "frame_checks": [{"name": "min_rows", "args": {"min_rows": 1}}],
+                "columns": {"a": {"dtype": "Int64"}},
+            }
+        )
+        df = pl.DataFrame({"a": [1, 2]})
+        result = schema.validate(df, registry)
+        assert result.data.collect()["a"].to_list() == [1, 2]
+
+    def test_frame_check_not_registered_raises(self, registry):
+        schema = SchemaModel.from_dict(
+            {
+                "frame_checks": [{"name": "does_not_exist"}],
+                "columns": {"a": {"dtype": "Int64"}},
+            }
+        )
+        with pytest.raises(PipelineError, match="not found in registry"):
+            schema.validate(pl.DataFrame({"a": [1]}), registry)
+
+
+# ---------------------------------------------------------------------------
 # Nullification (on_failure='null')
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This pull request introduces frame-level parsers and checks to the validation pipeline, allowing transformations and validations that operate on the entire DataFrame rather than individual columns. It updates both the implementation and documentation, and adds comprehensive tests to ensure correct phase ordering and error handling.

**Pipeline phase additions and integration:**

* Added `FrameParsingPhase` and `FrameCheckPhase` to the pipeline, enabling support for frame-level parsers (transformations) and checks (validations) that operate on the whole DataFrame. These phases are conditionally included based on the schema and are ordered so that frame parsers run before column parsers, and frame checks run after coercion but before column checks. [[1]](diffhunk://#diff-2277d474286a7464a32731f749e1205867364c33cbdcd10889513720a534433cR15-R16) [[2]](diffhunk://#diff-2277d474286a7464a32731f749e1205867364c33cbdcd10889513720a534433cR107-R109) [[3]](diffhunk://#diff-2277d474286a7464a32731f749e1205867364c33cbdcd10889513720a534433cR118-R120) [[4]](diffhunk://#diff-611d6e757c94d12e15c6e4b8e608eb2180ff13b0a0d7d5cafa6477ec1286d5ceR51-R52) [[5]](diffhunk://#diff-611d6e757c94d12e15c6e4b8e608eb2180ff13b0a0d7d5cafa6477ec1286d5ceR140-R204) [[6]](diffhunk://#diff-611d6e757c94d12e15c6e4b8e608eb2180ff13b0a0d7d5cafa6477ec1286d5ceR390-R455)

**Documentation updates:**

* Updated the user guide to explain frame-level parsers and checks, including an example of a frame check that enforces a minimum row count.
* Updated the pipeline design ADR to mark frame parser and check phases as implemented.

**Testing improvements:**

* Added tests to verify that the new phases are included in the pipeline only when appropriate, and that their ordering is correct relative to other phases.
* Added tests for frame-level parser and check registration, execution, error handling, and integration with the schema validation process.