### PR TITLE
add engine (streaming/in-memory) threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [0.2.0b1] - 2026-08-24
 
-First beta release under the validator-based architecture.
-This release is not backward compatible with 0.1.0; see [breaking changes](docs/releases/breaking-changes.md).
+First published release, and the first under the validator-based architecture.
+Everything before this was unreleased: the repository carried a `0.1.0` version string from its initial commit but was never tagged or published, so the entries below are measured against that unreleased state rather than against anything a user could have installed.
+See [breaking changes](docs/releases/breaking-changes.md).
 
 ### Added
 
@@ -71,18 +72,6 @@ This release is not backward compatible with 0.1.0; see [breaking changes](docs/
 - `strict`, `clean`, and `audit` validation profiles, replaced by `on_failure`.
 - The `coerce_strategy` parameter, replaced by per-column `on_failure`.
 
-## [0.1.0] - 2026-01-09
-
-Initial functional validation engine. Never tagged or published to PyPI.
-
-### Added
-
-- Schema definition via `SchemaModel.from_dict()`.
-- Column-level dtype validation and coercion.
-- Function registry for parsers and checks.
-- Error reporting in summary mode only.
-
 [Unreleased]: https://github.com/yannick-vinkesteijn/nyctea/compare/v0.2.0b2...HEAD
 [0.2.0b2]: https://github.com/yannick-vinkesteijn/nyctea/compare/v0.2.0b1...v0.2.0b2
 [0.2.0b1]: https://github.com/yannick-vinkesteijn/nyctea/releases/tag/v0.2.0b1
-[0.1.0]: https://github.com/yannick-vinkesteijn/nyctea/commit/4f374f5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Nyctea are recorded here.
 This file is maintained by hand and is the canonical account of what changed in each release.
-The auto-generated notes on each [GitHub Release](https://github.com/yannick-vinkesteijn/nyctea/releases) are a raw list of merged pull requests, useful as raw material but not curated.
+The auto-generated notes on each [GitHub Release](https://github.com/yannick-vinkesteijn/nyctea/releases) are a raw list of merged pull requests.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) as described in [Releasing](docs/development/RELEASING.md#versioning).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,88 @@
+# Changelog
+
+All notable changes to Nyctea are recorded here.
+This file is maintained by hand and is the canonical account of what changed in each release.
+The auto-generated notes on each [GitHub Release](https://github.com/yannick-vinkesteijn/nyctea/releases) are a raw list of merged pull requests, useful as raw material but not curated.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) as described in [Releasing](docs/development/RELEASING.md#versioning).
+
+## [Unreleased]
+
+### Added
+
+- Frame-level parsers and checks are now wired into the pipeline through `FrameParsingPhase` and `FrameCheckPhase`, instead of being accepted by the schema and silently ignored (#8).
+- `SchemaModel.streaming_row_threshold` controls whether validation's internal aggregate collects use Polars' streaming engine. Above the threshold they stream, which roughly halves peak memory on large data. Below it they use the default engine, since streaming's fixed setup cost is not worth paying on small data. A `LazyFrame` input always streams, since its size is unknown without collecting (#11).
+- `AggregateEngine` type alias, `Literal["in-memory", "streaming"]`.
+
+### Changed
+
+- The per-phase metrics block no longer collects when no observers are registered (#11).
+
+### Fixed
+
+- `on_failure` is now enforced for check failures, not only for coercion-introduced nulls. `raise` actually raises, and `null` actually nulls the failing value. Both were previously silent: the failure was recorded in `result.errors` while execution continued with the bad value still in the output (#9).
+- `_build_report` no longer reports every dataset as 100% valid. It is built from the same masks as `result.errors`, so `report` and `errors` agree (#6).
+- Per-column check failure counts in the report sum each check's failures rather than counting distinct failing rows, matching the totals in `errors`. A row failing two checks now contributes two failures in both places (#6).
+
+## [0.2.0b2] - 2026-08-24
+
+### Fixed
+
+- Dead `DEVELOPMENT.md` link in the PyPI README, the same root cause as the earlier logo path fix (#29).
+
+## [0.2.0b1] - 2026-08-24
+
+First beta release under the validator-based architecture.
+This release is not backward compatible with 0.1.0; see [breaking changes](docs/releases/breaking-changes.md).
+
+### Added
+
+- OOP validator architecture: `Validator` -> `ColumnValidator` -> `ColumnParser`/`ColumnCheck`.
+- `Registry` for registering and looking up parsers and checks by name.
+- `ValidationPipeline` composed of `PipelinePhase` objects, with `PipelineContext` carrying shared state across phases.
+- Pipeline phases: `ColumnResolutionPhase`, `ColumnParsingPhase`, `CoercionPhase`, `ColumnCheckPhase`.
+- `ErrorReportConfig` with three modes: `summary`, `rows`, `cells`.
+- `on_failure` at schema and column level, taking `raise`, `null`, or `ignore`.
+- Per-column `coerce` override of the schema default.
+- Column synonym resolution with ambiguity detection.
+- Decorator API, `@decorators.column_check` and `@decorators.column_parser`, for defining validators as plain functions.
+- Built-in parsers `strip`, `lower`, `upper`, `to_int`, `to_float`, and built-in checks `min_value`, `between`, `in_set`, `unique`.
+- Targeted error collection: only the mask and the relevant columns are collected, never the full frame.
+- Pre-null masks for distinguishing coercion-introduced nulls from nulls already present in the input.
+- Documentation site built with Zensical.
+- Trusted publishing to PyPI over OIDC, with a human-reviewed draft release step (#17, #18, #22).
+
+### Changed
+
+- `validate()` keeps the data lazy throughout. Error reporting and the report still use targeted collects, so the pipeline is not collect-free, but the data itself is never materialised.
+- Renamed the `plugins` module to `validators`.
+- Minimum supported Python raised to 3.11.
+
+### Fixed
+
+- `nullable: false` is now enforced. This changes behaviour for schemas that never declared `nullable: true` (#7).
+- `on_failure: "ignore"` on a non-nullable column now reports the null in `errors` under the check name `not_null`, instead of passing it through silently.
+- Generated mask columns (`__notnull__*`, `__check__*`, `__pre_null__*`) now raise on collision with a real input column, instead of overwriting it and dropping it from the output.
+- Removed `from __future__ import annotations` across the engine, validator, and schema modules (#13).
+- CI: dropped Python 3.10 from the test matrix, fixed lint violations, and repaired the stale registry import in the build smoke test (#14, #15, #16).
+
+### Removed
+
+- `strict`, `clean`, and `audit` validation profiles, replaced by `on_failure`.
+- The `coerce_strategy` parameter, replaced by per-column `on_failure`.
+
+## [0.1.0] - 2026-01-09
+
+Initial functional validation engine. Never tagged or published to PyPI.
+
+### Added
+
+- Schema definition via `SchemaModel.from_dict()`.
+- Column-level dtype validation and coercion.
+- Function registry for parsers and checks.
+- Error reporting in summary mode only.
+
+[Unreleased]: https://github.com/yannick-vinkesteijn/nyctea/compare/v0.2.0b2...HEAD
+[0.2.0b2]: https://github.com/yannick-vinkesteijn/nyctea/compare/v0.2.0b1...v0.2.0b2
+[0.2.0b1]: https://github.com/yannick-vinkesteijn/nyctea/releases/tag/v0.2.0b1
+[0.1.0]: https://github.com/yannick-vinkesteijn/nyctea/commit/4f374f5

--- a/docs/api/schema.md
+++ b/docs/api/schema.md
@@ -39,3 +39,13 @@ Controls what happens when coercion or checks fail. Set at schema level (default
 - `"raise"` - Error, stop. Default.
 - `"null"` - Value becomes null. Requires `nullable=True`.
 - `"ignore"` - Coercion nulls forced by dtype. Check failures kept as-is, reported.
+
+### AggregateEngine
+
+```python
+AggregateEngine = Literal["in-memory", "streaming"]
+```
+
+The Polars engine used for validation's internal aggregate collects.
+Chosen per `validate()` call from `SchemaModel.streaming_row_threshold`, never set directly.
+See [streaming engine for internal aggregates](../user-guide/features.md#streaming-engine-for-internal-aggregates).

--- a/docs/development/RELEASING.md
+++ b/docs/development/RELEASING.md
@@ -18,9 +18,13 @@ A tag push does not publish anything by itself; a human always reviews a draft f
 5. Review the draft. This is the point to edit the notes if the auto-generated summary needs a human pass, not a step to skip. Click **Publish**.
 6. Publishing the release fires **`Publish to PyPI`** (`pypi-publish.yaml`). It builds the package and uploads it to PyPI through trusted publishing, with no token and no manual `uv publish`.
 
-There is no maintained `CHANGELOG.md`. The GitHub Release for each tag is the changelog, the same
-way Polars does it. Label PRs correctly (`bug`, `enhancement`, `documentation`, `breaking`) so
-`.github/release.yml` sorts them into the right section automatically.
+`CHANGELOG.md` in the repository root is maintained by hand and is the canonical account of what changed.
+Move the `[Unreleased]` entries under the new version heading as part of step 1, in the same commit as the version bump, and add a fresh empty `[Unreleased]` section above it.
+Update the link definitions at the bottom of the file too.
+
+The auto-generated GitHub Release notes are not a replacement for it.
+They list merged pull requests grouped by label, which is useful raw material but not a curated account of behaviour changes.
+Label PRs correctly (`bug`, `enhancement`, `documentation`, `breaking`) so `.github/release.yml` still sorts them sensibly, and paste the relevant `CHANGELOG.md` section into the draft release when reviewing it at step 5.
 
 ## `scripts/release.sh` is superseded, do not use it
 

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -3,7 +3,8 @@
 Version history and upgrade notes.
 
 - **[Breaking changes](breaking-changes.md)**: what changed between versions and how to migrate.
-- **[GitHub Releases](https://github.com/yannick-vinkesteijn/nyctea/releases)**: full release notes for every version.
+- **[Changelog](https://github.com/yannick-vinkesteijn/nyctea/blob/main/CHANGELOG.md)**: the maintained account of what changed in every release.
+- **[GitHub Releases](https://github.com/yannick-vinkesteijn/nyctea/releases)**: the auto-generated pull request list behind each tag.
 
 Nyctea follows [Semantic Versioning](https://semver.org/). Until 1.0, minor versions may carry
 breaking changes. These are always documented in the breaking changes page above.

--- a/docs/user-guide/features.md
+++ b/docs/user-guide/features.md
@@ -17,6 +17,28 @@ result = schema.validate(df, registry)        # result.data is a LazyFrame
 result = schema.validate(df, registry, lazy=False)  # result.data is a DataFrame
 ```
 
+## Streaming engine for internal aggregates
+
+Validation's internal collects (check enforcement, error and report building) are pure reductions: sums, lengths, boolean `all()`.
+Above `schema.streaming_row_threshold` rows, they use Polars' streaming engine, which cuts peak memory substantially on large data.
+Below it, they use the default engine, since streaming has a fixed per-query setup cost that outweighs the reduction itself on small data.
+The default threshold is 100,000 rows, based on a measured crossover.
+Override it per schema if your workload sits far from that:
+
+```python
+schema = SchemaModel.from_dict({
+    "streaming_row_threshold": 10_000,  # lower it if you mostly validate large files
+    "columns": {"age": {"dtype": "Int64"}},
+})
+```
+
+A `LazyFrame` input always uses streaming, since its row count isn't known without collecting, and passing lazy input in the first place signals larger or out-of-core data.
+
+These internal collects always pass an explicit `engine=` value, so they don't respect [`pl.Config.set_engine_affinity()`](https://docs.pola.rs/api/python/stable/reference/api/polars.Config.set_engine_affinity.html) or the `POLARS_ENGINE_AFFINITY` environment variable, unlike `engine="auto"` calls elsewhere in your own code.
+That is deliberate.
+`streaming_row_threshold` is a per-query decision that knows how much data it is looking at, while Polars' engine affinity is a single global switch with no size awareness (see the `engine` parameter on [`LazyFrame.collect`](https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.collect.html)).
+If your global affinity is set to `"streaming"`, nyctea's internal aggregates on small data still use the default engine unless you lower `streaming_row_threshold` yourself.
+
 ## Composable pipeline
 
 Validation runs through ordered phases. Each phase receives a `PipelineContext` and returns it with updated state.

--- a/docs/user-guide/features.md
+++ b/docs/user-guide/features.md
@@ -35,13 +35,15 @@ schema = SchemaModel.from_dict({
 A `LazyFrame` input always uses streaming, since its row count isn't known without collecting, and passing lazy input in the first place signals larger or out-of-core data.
 
 The `rows` and `cells` error report modes are the exception.
-They materialise row indices and failing values rather than reducing them, so they always use the default engine regardless of the threshold.
+They materialise row indices and failing values rather than reducing them, so the threshold does not apply to them and they pass no `engine=` at all.
+That leaves them on Polars' own default selection, `engine="auto"`, which means they do follow your global affinity setting where the aggregates below deliberately do not.
 Only the `summary` mode's error counts are an aggregate.
 
 These aggregate collects always pass an explicit `engine=` value, so they don't respect [`pl.Config.set_engine_affinity()`](https://docs.pola.rs/api/python/stable/reference/api/polars.Config.set_engine_affinity.html) or the `POLARS_ENGINE_AFFINITY` environment variable, unlike `engine="auto"` calls elsewhere in your own code.
 That is deliberate.
 `streaming_row_threshold` is a per-query decision that knows how much data it is looking at, while Polars' engine affinity is a single global switch with no size awareness (see the `engine` parameter on [`LazyFrame.collect`](https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.collect.html)).
-If your global affinity is set to `"streaming"`, nyctea's internal aggregates on small data still use the default engine unless you lower `streaming_row_threshold` yourself.
+If your global affinity is set to `"streaming"`, nyctea's internal aggregates on small data still use the in-memory engine unless you lower `streaming_row_threshold` yourself.
+The `rows` and `cells` collects described above are the ones that will follow it, since they leave the choice to Polars.
 
 ## Composable pipeline
 

--- a/docs/user-guide/features.md
+++ b/docs/user-guide/features.md
@@ -19,7 +19,7 @@ result = schema.validate(df, registry, lazy=False)  # result.data is a DataFrame
 
 ## Streaming engine for internal aggregates
 
-Validation's internal collects (check enforcement, error and report building) are pure reductions: sums, lengths, boolean `all()`.
+Validation's internal aggregate collects (check and coercion enforcement, summary error counts, report building) are pure reductions: sums, lengths, boolean `all()`.
 Above `schema.streaming_row_threshold` rows, they use Polars' streaming engine, which cuts peak memory substantially on large data.
 Below it, they use the default engine, since streaming has a fixed per-query setup cost that outweighs the reduction itself on small data.
 The default threshold is 100,000 rows, based on a measured crossover.
@@ -34,7 +34,11 @@ schema = SchemaModel.from_dict({
 
 A `LazyFrame` input always uses streaming, since its row count isn't known without collecting, and passing lazy input in the first place signals larger or out-of-core data.
 
-These internal collects always pass an explicit `engine=` value, so they don't respect [`pl.Config.set_engine_affinity()`](https://docs.pola.rs/api/python/stable/reference/api/polars.Config.set_engine_affinity.html) or the `POLARS_ENGINE_AFFINITY` environment variable, unlike `engine="auto"` calls elsewhere in your own code.
+The `rows` and `cells` error report modes are the exception.
+They materialise row indices and failing values rather than reducing them, so they always use the default engine regardless of the threshold.
+Only the `summary` mode's error counts are an aggregate.
+
+These aggregate collects always pass an explicit `engine=` value, so they don't respect [`pl.Config.set_engine_affinity()`](https://docs.pola.rs/api/python/stable/reference/api/polars.Config.set_engine_affinity.html) or the `POLARS_ENGINE_AFFINITY` environment variable, unlike `engine="auto"` calls elsewhere in your own code.
 That is deliberate.
 `streaming_row_threshold` is a per-query decision that knows how much data it is looking at, while Polars' engine affinity is a single global switch with no size awareness (see the `engine` parameter on [`LazyFrame.collect`](https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.collect.html)).
 If your global affinity is set to `"streaming"`, nyctea's internal aggregates on small data still use the default engine unless you lower `streaming_row_threshold` yourself.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ Homepage = "https://github.com/yannick-vinkesteijn/nyctea"
 Documentation = "https://nyctea.vinkesteijn.io/"
 Repository = "https://github.com/yannick-vinkesteijn/nyctea"
 Issues = "https://github.com/yannick-vinkesteijn/nyctea/issues"
-Changelog = "https://github.com/yannick-vinkesteijn/nyctea/releases"
+Changelog = "https://github.com/yannick-vinkesteijn/nyctea/blob/main/CHANGELOG.md"
 
 [build-system]
 requires = ["uv_build>=0.9.17,<0.10.0"]

--- a/src/nyctea/engine/context.py
+++ b/src/nyctea/engine/context.py
@@ -10,7 +10,7 @@ from typing import Any
 import polars as pl
 
 from nyctea.engine.validate import ErrorReportConfig, ValidationReport
-from nyctea.schema.model import SchemaModel
+from nyctea.schema.model import AggregateEngine, SchemaModel
 from nyctea.validators.registry import Registry
 
 __all__ = ["PipelineContext"]
@@ -36,6 +36,10 @@ class PipelineContext:
         errors: Error DataFrame (built by ErrorReportingPhase).
         report: Final validation report (built by ReportGenerationPhase).
         metadata: Additional phase-specific metadata.
+        aggregate_engine: Polars ``collect()`` engine for internal reduction-only
+            aggregates (not for materializing rows). Decided once per ``validate()``
+            call from ``schema.streaming_row_threshold`` before the pipeline runs,
+            so every phase and post-pipeline step uses the same choice.
     """
 
     # Input configuration
@@ -43,6 +47,7 @@ class PipelineContext:
     schema: SchemaModel
     registry: Registry
     error_report_config: ErrorReportConfig | None = None
+    aggregate_engine: AggregateEngine = "in-memory"
 
     # Tracking state (populated by phases)
     original_nulls: dict[str, int] = field(default_factory=dict)

--- a/src/nyctea/engine/phases.py
+++ b/src/nyctea/engine/phases.py
@@ -613,7 +613,7 @@ class ColumnCheckPhase(PipelinePhase):
         # Aggregate first: collects a single row, not one boolean per input row.
         notnull_check = context.data.select(
             [pl.col(alias).all().alias(alias) for alias in notnull_aliases.values()]
-        ).collect()
+        ).collect(engine=context.aggregate_engine)
         for col_name, alias in notnull_aliases.items():
             if not notnull_check[alias].item() and context.schema.resolve_on_failure(col_name) != "ignore":
                 raise PipelineError(

--- a/src/nyctea/engine/pipeline.py
+++ b/src/nyctea/engine/pipeline.py
@@ -337,16 +337,16 @@ class ValidationPipeline:
             ) from e
         phase_duration = time.time() - phase_start
 
-        metrics = PhaseMetrics(
-            phase_name=phase.name,
-            duration_seconds=phase_duration,
-            rows_processed=context.data.select("__row_index__").collect().height
-            if "__row_index__" in context.data.collect_schema().names()
-            else 0,
-        )
-
-        for observer in self.observers:
-            observer.on_phase_end(phase.name, context, metrics)
+        if self.observers:
+            metrics = PhaseMetrics(
+                phase_name=phase.name,
+                duration_seconds=phase_duration,
+                rows_processed=context.data.select("__row_index__").collect().height
+                if "__row_index__" in context.data.collect_schema().names()
+                else 0,
+            )
+            for observer in self.observers:
+                observer.on_phase_end(phase.name, context, metrics)
 
         return context
 

--- a/src/nyctea/schema/model.py
+++ b/src/nyctea/schema/model.py
@@ -180,7 +180,7 @@ class SchemaModel(BaseModel):
     )
 
     streaming_row_threshold: int = Field(
-        100_000,
+        100_000, ge=0,
         description=(
             "Row count at or above which internal reduction-only aggregates (check "
             "and coercion enforcement, error/report building) use Polars' streaming "

--- a/src/nyctea/schema/model.py
+++ b/src/nyctea/schema/model.py
@@ -185,14 +185,17 @@ class SchemaModel(BaseModel):
         description=(
             "Row count at or above which internal reduction-only aggregates (check "
             "and coercion enforcement, summary error counts, report building) use "
-            "Polars' streaming "
-            "engine instead of the default in-memory engine. Below this, an eager "
-            "DataFrame input uses the default engine, since streaming's fixed "
-            "pipeline setup cost outweighs the reduction itself on small data. A "
-            "LazyFrame input always uses streaming, since its size is unknown "
-            "without collecting and choosing lazy signals larger/out-of-core intent. "
-            "The 'rows' and 'cells' error report modes are not aggregates -- they "
-            "materialise row indices and values, and always use the default engine."
+            "Polars' streaming engine instead of the in-memory one. Below this, an "
+            "eager DataFrame input uses the in-memory engine, since streaming's "
+            "fixed pipeline setup cost outweighs the reduction itself on small "
+            "data. A LazyFrame input always uses streaming, since its size is "
+            "unknown without collecting and choosing lazy signals "
+            "larger/out-of-core intent. Those aggregates pass engine= explicitly, "
+            "so this threshold overrides any global engine affinity. The 'rows' "
+            "and 'cells' error report modes are not aggregates -- they materialise "
+            "row indices and values, pass no engine= at all, and so fall to Polars' "
+            "own default selection (engine='auto'), which does follow your global "
+            "affinity. 0 means always stream."
         ),
     )
 

--- a/src/nyctea/schema/model.py
+++ b/src/nyctea/schema/model.py
@@ -44,6 +44,9 @@ if TYPE_CHECKING:
 # Type alias for failure handling behavior
 OnFailureBehavior = Literal["raise", "null", "ignore"]
 
+# Type alias for the Polars engine used by validation's internal aggregate collects
+AggregateEngine = Literal["in-memory", "streaming"]
+
 try:
     import yaml
 except ImportError:
@@ -173,6 +176,19 @@ class SchemaModel(BaseModel):
             "- 'raise': error, stop\n"
             "- 'null': value becomes null\n"
             "- 'ignore': coercion nulls forced by dtype, check failures kept and reported"
+        ),
+    )
+
+    streaming_row_threshold: int = Field(
+        100_000,
+        description=(
+            "Row count at or above which internal reduction-only aggregates (check "
+            "and coercion enforcement, error/report building) use Polars' streaming "
+            "engine instead of the default in-memory engine. Below this, an eager "
+            "DataFrame input uses the default engine, since streaming's fixed "
+            "pipeline setup cost outweighs the reduction itself on small data. A "
+            "LazyFrame input always uses streaming, since its size is unknown "
+            "without collecting and choosing lazy signals larger/out-of-core intent."
         ),
     )
 

--- a/src/nyctea/schema/model.py
+++ b/src/nyctea/schema/model.py
@@ -180,15 +180,19 @@ class SchemaModel(BaseModel):
     )
 
     streaming_row_threshold: int = Field(
-        100_000, ge=0,
+        100_000,
+        ge=0,
         description=(
             "Row count at or above which internal reduction-only aggregates (check "
-            "and coercion enforcement, error/report building) use Polars' streaming "
+            "and coercion enforcement, summary error counts, report building) use "
+            "Polars' streaming "
             "engine instead of the default in-memory engine. Below this, an eager "
             "DataFrame input uses the default engine, since streaming's fixed "
             "pipeline setup cost outweighs the reduction itself on small data. A "
             "LazyFrame input always uses streaming, since its size is unknown "
-            "without collecting and choosing lazy signals larger/out-of-core intent."
+            "without collecting and choosing lazy signals larger/out-of-core intent. "
+            "The 'rows' and 'cells' error report modes are not aggregates -- they "
+            "materialise row indices and values, and always use the default engine."
         ),
     )
 

--- a/src/nyctea/schema/validator.py
+++ b/src/nyctea/schema/validator.py
@@ -14,7 +14,7 @@ from nyctea.engine.phases import COERCION_CHECK, NOT_NULL_CHECK
 from nyctea.engine.pipeline import ValidationPipeline
 from nyctea.engine.validate import ColumnValidationStats, ErrorReportConfig, ValidationReport, ValidationResult
 from nyctea.exceptions import PipelineError
-from nyctea.schema.model import SchemaModel
+from nyctea.schema.model import AggregateEngine, SchemaModel
 from nyctea.validators.registry import Registry
 
 __all__ = ["SchemaValidator"]
@@ -30,6 +30,37 @@ def _collect(lf: pl.LazyFrame) -> pl.DataFrame:
     result = lf.collect()
     assert isinstance(result, pl.DataFrame)
     return result
+
+
+def _collect_aggregate(lf: pl.LazyFrame, engine: AggregateEngine) -> pl.DataFrame:
+    """Collect a LazyFrame of pure reduction expressions (sum/len/all/any_horizontal).
+
+    Streaming roughly halves peak memory on these (#11) with no correctness
+    difference, since none of the reductions used here are approximation-based
+    (unlike e.g. ``approx_n_unique``, which does disagree between engines). Not for
+    row- or cell-level materialization -- those need the default engine.
+
+    ``engine`` is decided once per ``validate()`` call (see
+    ``schema.streaming_row_threshold``) and threaded in via
+    ``context.aggregate_engine`` rather than hardcoded, since streaming has a fixed
+    per-query setup cost that makes it slower than the default engine on small data.
+    """
+    result = lf.collect(engine=engine)
+    assert isinstance(result, pl.DataFrame)
+    return result
+
+
+def _pick_aggregate_engine(df: pl.DataFrame | pl.LazyFrame, threshold: int) -> AggregateEngine:
+    """Decide the engine for this validate() call's internal aggregate collects.
+
+    A LazyFrame input's size is unknown without collecting, and choosing lazy is
+    itself a signal of larger/out-of-core intent, so it always gets streaming. An
+    eager DataFrame's row count is free (``.height``), so it only pays streaming's
+    setup cost once the data is actually large enough to benefit.
+    """
+    if isinstance(df, pl.DataFrame) and df.height < threshold:
+        return "in-memory"
+    return "streaming"
 
 
 class SchemaValidator:
@@ -109,6 +140,10 @@ class SchemaValidator:
             ...     print(f"Found {len(result.errors)} errors")
             >>> print(result.report.summary())
         """
+        # Decided from the original df (before the LazyFrame conversion below), since
+        # only the eager form has a free row count to threshold on.
+        aggregate_engine = _pick_aggregate_engine(df, self.schema.streaming_row_threshold)
+
         # Convert to LazyFrame
         lf = df.lazy() if isinstance(df, pl.DataFrame) else df
 
@@ -121,6 +156,7 @@ class SchemaValidator:
             schema=self.schema,
             registry=self.registry,
             error_report_config=error_report_config or ErrorReportConfig(),
+            aggregate_engine=aggregate_engine,
         )
 
         # Execute pipeline (fully lazy — no collects inside phases)
@@ -183,7 +219,7 @@ class SchemaValidator:
         count_exprs = [
             (~pl.col(alias)).sum().alias(f"__new_nulls__{col_name}") for col_name, alias in raise_cols.items()
         ]
-        counts = _collect(context.data.select(count_exprs))
+        counts = _collect_aggregate(context.data.select(count_exprs), context.aggregate_engine)
         for col_name in raise_cols:
             new_nulls = int(counts[f"__new_nulls__{col_name}"].item())
             if new_nulls > 0:
@@ -244,7 +280,7 @@ class SchemaValidator:
             pl.any_horizontal([~pl.col(alias) for alias in aliases]).sum().alias(f"__check_fail__{col_name}")
             for col_name, aliases in raise_cols.items()
         ]
-        counts = _collect(context.data.select(count_exprs))
+        counts = _collect_aggregate(context.data.select(count_exprs), context.aggregate_engine)
         for col_name in raise_cols:
             fail_count = int(counts[f"__check_fail__{col_name}"].item())
             if fail_count > 0:
@@ -273,10 +309,11 @@ class SchemaValidator:
             col_name: pl.any_horizontal([~pl.col(alias) for alias in aliases])
             for col_name, aliases in null_cols.items()
         }
-        counts = _collect(
+        counts = _collect_aggregate(
             context.data.select(
                 [expr.sum().alias(f"__check_fail__{col_name}") for col_name, expr in fail_exprs.items()]
-            )
+            ),
+            context.aggregate_engine,
         )
         for col_name in null_cols:
             context.nullified_counts[col_name] = context.nullified_counts.get(col_name, 0) + int(
@@ -336,7 +373,7 @@ class SchemaValidator:
         report_cols = [c for c in schema.columns if c in col_names]
         exprs.extend(pl.col(col_name).is_null().sum().alias(f"__final_null__{col_name}") for col_name in report_cols)
 
-        row = _collect(lf.select(exprs))
+        row = _collect_aggregate(lf.select(exprs), context.aggregate_engine)
 
         total = int(row["__total__"].item())
         rows_failed = int(row["__rows_failed__"].item()) if "__rows_failed__" in row.columns else 0
@@ -385,25 +422,21 @@ class SchemaValidator:
             "rows": self._build_errors_rows,
             "cells": self._build_errors_cells,
         }
-        return builders[config.mode](context.check_masks, context.data, config)
+        return builders[config.mode](context, config)
 
-    def _build_errors_summary(
-        self,
-        check_masks: dict[tuple[str, str], str],
-        lf: pl.LazyFrame,
-        config: ErrorReportConfig,
-    ) -> pl.DataFrame:
+    def _build_errors_summary(self, context: PipelineContext, config: ErrorReportConfig) -> pl.DataFrame:
         """Build summary error report: column | check | count.
 
         Single 1-row aggregation collect.
         """
+        check_masks = context.check_masks
         empty_schema = {"column": pl.String, "check": pl.String, "count": pl.UInt32}
         empty = pl.DataFrame({"column": [], "check": [], "count": []}, schema=empty_schema)
         if not check_masks:
             return empty
 
         count_exprs = [(~pl.col(alias)).sum().cast(pl.UInt32).alias(alias) for alias in check_masks.values()]
-        counts = _collect(lf.select(count_exprs))
+        counts = _collect_aggregate(context.data.select(count_exprs), context.aggregate_engine)
 
         rows: list[dict[str, str | int]] = []
         for (col_name, check_name), alias in check_masks.items():
@@ -415,16 +448,13 @@ class SchemaValidator:
             return empty
         return pl.DataFrame(rows, schema=empty_schema)
 
-    def _build_errors_rows(
-        self,
-        check_masks: dict[tuple[str, str], str],
-        lf: pl.LazyFrame,
-        config: ErrorReportConfig,
-    ) -> pl.DataFrame:
+    def _build_errors_rows(self, context: PipelineContext, config: ErrorReportConfig) -> pl.DataFrame:
         """Build rows error report: column | check | count | row_indices.
 
-        Collects only __row_index__ + mask columns.
+        Collects only __row_index__ + mask columns. Row materialization stays on the
+        default engine, unlike the summary builder's pure aggregate.
         """
+        check_masks = context.check_masks
         empty_schema = {
             "column": pl.String,
             "check": pl.String,
@@ -439,7 +469,7 @@ class SchemaValidator:
             return empty
 
         mask_aliases = list(check_masks.values())
-        subset = _collect(lf.select(["__row_index__", *mask_aliases]))
+        subset = _collect(context.data.select(["__row_index__", *mask_aliases]))
         row_index = subset.get_column("__row_index__")
 
         rows: list[dict[str, object]] = []
@@ -462,16 +492,14 @@ class SchemaValidator:
             return empty
         return pl.DataFrame(rows, schema=empty_schema)
 
-    def _build_errors_cells(
-        self,
-        check_masks: dict[tuple[str, str], str],
-        lf: pl.LazyFrame,
-        config: ErrorReportConfig,
-    ) -> pl.DataFrame:
+    def _build_errors_cells(self, context: PipelineContext, config: ErrorReportConfig) -> pl.DataFrame:
         """Build cells error report: column | check | row_index | value.
 
         Collects only __row_index__ + mask columns + data columns with failing checks.
+        Cell materialization stays on the default engine, unlike the summary builder's
+        pure aggregate.
         """
+        check_masks = context.check_masks
         empty_schema = {
             "column": pl.String,
             "check": pl.String,
@@ -488,7 +516,7 @@ class SchemaValidator:
         # Collect only the columns we need: row_index + masks + data columns with checks
         mask_aliases = list(check_masks.values())
         data_cols = list({col_name for (col_name, _) in check_masks})
-        subset = _collect(lf.select(["__row_index__", *mask_aliases, *data_cols]))
+        subset = _collect(context.data.select(["__row_index__", *mask_aliases, *data_cols]))
         row_index = subset.get_column("__row_index__")
 
         parts: list[pl.DataFrame] = []

--- a/tests/engine/conftest.py
+++ b/tests/engine/conftest.py
@@ -1,0 +1,22 @@
+"""Shared fixtures for engine-level tests."""
+
+import polars as pl
+import pytest
+
+
+@pytest.fixture
+def collect_calls(monkeypatch):
+    """Record each pl.LazyFrame.collect() call's kwargs, in call order.
+
+    Use len(calls) to assert collect count, or calls[i].get("engine") to
+    assert which engine a specific call used.
+    """
+    calls = []
+    orig_collect = pl.LazyFrame.collect
+
+    def recording_collect(self, *args, **kwargs):
+        calls.append(kwargs)
+        return orig_collect(self, *args, **kwargs)
+
+    monkeypatch.setattr(pl.LazyFrame, "collect", recording_collect)
+    return calls

--- a/tests/engine/test_phases.py
+++ b/tests/engine/test_phases.py
@@ -366,6 +366,31 @@ class TestFullPipeline:
         assert collect_calls
         assert all(call.get("engine") == "streaming" for call in collect_calls)
 
+    @pytest.mark.parametrize("mode", ["rows", "cells"])
+    def test_row_and_cell_error_modes_never_stream(self, registry, collect_calls, mode):
+        """#11 step 4: only pure reductions stream.
+
+        The rows/cells error builders materialize row indices and failing values, so
+        they call plain _collect() with no engine kwarg even when the frame is well
+        above streaming_row_threshold and every aggregate around them is streaming.
+        """
+        schema = SchemaModel.from_dict(
+            {
+                "streaming_row_threshold": 10,
+                "on_failure": "ignore",
+                "columns": {
+                    "age": {"dtype": "Int64", "nullable": True, "checks": [{"name": "min_value", "args": {"min": 0}}]}
+                },
+            }
+        )
+        df = pl.DataFrame({"age": [*range(19), -1]})
+        result = schema.validate(df, registry, error_report_config=ErrorReportConfig(mode=mode))
+
+        assert len(result.errors) == 1
+        engines = [call.get("engine") for call in collect_calls]
+        assert "streaming" in engines, "the aggregate collects should still stream above the threshold"
+        assert None in engines, "the row/cell materialization should use the default engine"
+
     def test_check_failure_recorded(self, registry):
         schema = SchemaModel.from_dict(
             {

--- a/tests/engine/test_phases.py
+++ b/tests/engine/test_phases.py
@@ -248,6 +248,43 @@ class TestCoercionPhase:
 
 
 # ---------------------------------------------------------------------------
+# _collect / _collect_aggregate engine selection (#11 step 4)
+# ---------------------------------------------------------------------------
+
+
+class TestCollectEngineSelection:
+    def test_collect_aggregate_passes_through_requested_engine(self, collect_calls):
+        from nyctea.schema.validator import _collect_aggregate
+
+        _collect_aggregate(pl.LazyFrame({"a": [1, 2, 3]}).select(pl.col("a").sum()), "streaming")
+        assert collect_calls[0].get("engine") == "streaming"
+
+    def test_collect_uses_default_engine(self, collect_calls):
+        from nyctea.schema.validator import _collect
+
+        _collect(pl.LazyFrame({"a": [1, 2, 3]}))
+        assert collect_calls[0].get("engine") is None
+
+    def test_pick_aggregate_engine_dataframe_below_threshold(self):
+        from nyctea.schema.validator import _pick_aggregate_engine
+
+        df = pl.DataFrame({"a": range(100)})
+        assert _pick_aggregate_engine(df, threshold=1000) == "in-memory"
+
+    def test_pick_aggregate_engine_dataframe_at_or_above_threshold(self):
+        from nyctea.schema.validator import _pick_aggregate_engine
+
+        df = pl.DataFrame({"a": range(1000)})
+        assert _pick_aggregate_engine(df, threshold=1000) == "streaming"
+
+    def test_pick_aggregate_engine_lazyframe_always_streaming(self):
+        from nyctea.schema.validator import _pick_aggregate_engine
+
+        lf = pl.LazyFrame({"a": [1, 2, 3]})
+        assert _pick_aggregate_engine(lf, threshold=1_000_000) == "streaming"
+
+
+# ---------------------------------------------------------------------------
 # Full pipeline integration
 # ---------------------------------------------------------------------------
 
@@ -259,6 +296,75 @@ class TestFullPipeline:
         assert result.report.rows_processed == 3
         assert result.report.rows_valid == 3
         assert len(result.errors) == 0
+
+    def test_validate_collect_count_is_bounded(self, simple_schema, registry, collect_calls):
+        """#11: guards against silently regaining wasted collects.
+
+        4 today: _enforce_notnull, _enforce_check_raise, _build_errors, _build_report.
+        Expected to drop once #38 merges these into one pass -- update this count
+        deliberately when that lands, don't just raise the bound to make it pass.
+        """
+        df = pl.DataFrame({"age": [25, 30, 40], "name": ["Alice", "Bob", "Carol"]})
+        simple_schema.validate(df, registry)
+
+        assert len(collect_calls) == 4
+
+    def test_validate_collect_count_is_bounded_with_coercion_active(self, registry, collect_calls):
+        """Same guard as above, but for the path with coercion's own raise-check active.
+
+        5 today: _enforce_notnull, _enforce_coercion_raise, _enforce_check_raise,
+        _build_errors, _build_report. The issue this guards against (#11) specifically
+        called out that this path, not the no-coercion one, is the one most likely to
+        regain a collect.
+        """
+        schema = SchemaModel.from_dict(
+            {
+                "coerce": True,
+                "columns": {
+                    "age": {
+                        "dtype": "Int64",
+                        "nullable": False,
+                        "checks": [{"name": "min_value", "args": {"min": 0}}],
+                    }
+                },
+            }
+        )
+        df = pl.DataFrame({"age": ["10", "20", "30"]})
+        schema.validate(df, registry)
+
+        assert len(collect_calls) == 5
+
+    def test_small_dataframe_input_uses_default_engine(self, simple_schema, registry, collect_calls):
+        """Below schema.streaming_row_threshold, an eager DataFrame stays on the
+        default engine -- streaming's fixed setup cost regresses small validations.
+        """
+        df = pl.DataFrame({"age": [25, 30, 40], "name": ["Alice", "Bob", "Carol"]})
+        simple_schema.validate(df, registry)
+
+        assert collect_calls
+        assert all(call.get("engine") == "in-memory" for call in collect_calls)
+
+    def test_large_dataframe_input_uses_streaming_engine(self, registry, collect_calls):
+        schema = SchemaModel.from_dict(
+            {
+                "streaming_row_threshold": 10,
+                "columns": {"age": {"dtype": "Int64", "nullable": True}},
+            }
+        )
+        df = pl.DataFrame({"age": list(range(20))})
+        schema.validate(df, registry)
+
+        assert collect_calls
+        assert all(call.get("engine") == "streaming" for call in collect_calls)
+
+    def test_lazyframe_input_always_uses_streaming_engine(self, registry, collect_calls):
+        """Unknown size (no free row count), and choosing lazy signals larger intent."""
+        schema = SchemaModel.from_dict({"columns": {"age": {"dtype": "Int64", "nullable": True}}})
+        lf = pl.LazyFrame({"age": [1, 2, 3]})
+        schema.validate(lf, registry)
+
+        assert collect_calls
+        assert all(call.get("engine") == "streaming" for call in collect_calls)
 
     def test_check_failure_recorded(self, registry):
         schema = SchemaModel.from_dict(
@@ -705,6 +811,29 @@ class TestNullification:
         result = schema.validate(df, registry)
         assert result.report.columns["age"].coercion_failures == 0
         assert result.report.columns["age"].nullified == 1
+
+    def test_both_coercion_and_check_nulls_coexist_under_streaming_aggregate(self, registry):
+        """#11 step 4: the streaming-engine aggregate collect in _apply_check_null must
+        agree with the with_columns mutation that follows it on the same lazy graph.
+        """
+        schema = SchemaModel.from_dict(
+            {
+                "coerce": True,
+                "on_failure": "null",
+                "columns": {
+                    "age": {
+                        "dtype": "Int64",
+                        "nullable": True,
+                        "checks": [{"name": "min_value", "args": {"min": 0}}],
+                    }
+                },
+            }
+        )
+        df = pl.DataFrame({"age": ["10", "-1", "bad", "20"]})
+        result = schema.validate(df, registry)
+        assert result.data.collect()["age"].to_list() == [10, None, None, 20]
+        assert result.report.columns["age"].nullified == 1
+        assert result.report.columns["age"].coercion_failures == 1
 
     def test_coercion_failures_are_reported(self, registry):
         schema = SchemaModel.from_dict(

--- a/tests/engine/test_phases.py
+++ b/tests/engine/test_phases.py
@@ -283,6 +283,16 @@ class TestCollectEngineSelection:
         lf = pl.LazyFrame({"a": [1, 2, 3]})
         assert _pick_aggregate_engine(lf, threshold=1_000_000) == "streaming"
 
+    def test_threshold_rejects_negative(self):
+        """A negative row count is meaningless and would silently invert engine choice."""
+        with pytest.raises(ValueError, match="greater than or equal to 0"):
+            SchemaModel.from_dict({"streaming_row_threshold": -1, "columns": {"a": {"dtype": "Int64"}}})
+
+    def test_threshold_allows_zero(self):
+        """0 is the deliberate boundary: stream everything, including empty frames."""
+        schema = SchemaModel.from_dict({"streaming_row_threshold": 0, "columns": {"a": {"dtype": "Int64"}}})
+        assert schema.streaming_row_threshold == 0
+
 
 # ---------------------------------------------------------------------------
 # Full pipeline integration
@@ -367,12 +377,15 @@ class TestFullPipeline:
         assert all(call.get("engine") == "streaming" for call in collect_calls)
 
     @pytest.mark.parametrize("mode", ["rows", "cells"])
-    def test_rows_cells_never_stream(self, registry, collect_calls, mode):
-        """#11 step 4: only pure reductions stream.
+    def test_rows_cells_no_engine_override(self, registry, collect_calls, mode):
+        """#11 step 4: only pure reductions get an explicit engine.
 
         The rows/cells error builders materialize row indices and failing values, so
         they call plain _collect() with no engine kwarg even when the frame is well
         above streaming_row_threshold and every aggregate around them is streaming.
+        Absence of the kwarg is the contract: it leaves those two on Polars' own
+        engine="auto" selection, which follows global affinity. It does not mean they
+        can never stream.
         """
         schema = SchemaModel.from_dict(
             {

--- a/tests/engine/test_phases.py
+++ b/tests/engine/test_phases.py
@@ -253,7 +253,7 @@ class TestCoercionPhase:
 
 
 class TestCollectEngineSelection:
-    def test_collect_aggregate_passes_through_requested_engine(self, collect_calls):
+    def test_collect_aggregate_uses_given_engine(self, collect_calls):
         from nyctea.schema.validator import _collect_aggregate
 
         _collect_aggregate(pl.LazyFrame({"a": [1, 2, 3]}).select(pl.col("a").sum()), "streaming")
@@ -265,19 +265,19 @@ class TestCollectEngineSelection:
         _collect(pl.LazyFrame({"a": [1, 2, 3]}))
         assert collect_calls[0].get("engine") is None
 
-    def test_pick_aggregate_engine_dataframe_below_threshold(self):
+    def test_pick_engine_df_below_threshold(self):
         from nyctea.schema.validator import _pick_aggregate_engine
 
         df = pl.DataFrame({"a": range(100)})
         assert _pick_aggregate_engine(df, threshold=1000) == "in-memory"
 
-    def test_pick_aggregate_engine_dataframe_at_or_above_threshold(self):
+    def test_pick_engine_df_above_threshold(self):
         from nyctea.schema.validator import _pick_aggregate_engine
 
         df = pl.DataFrame({"a": range(1000)})
         assert _pick_aggregate_engine(df, threshold=1000) == "streaming"
 
-    def test_pick_aggregate_engine_lazyframe_always_streaming(self):
+    def test_pick_engine_lazyframe_streams(self):
         from nyctea.schema.validator import _pick_aggregate_engine
 
         lf = pl.LazyFrame({"a": [1, 2, 3]})
@@ -297,7 +297,7 @@ class TestFullPipeline:
         assert result.report.rows_valid == 3
         assert len(result.errors) == 0
 
-    def test_validate_collect_count_is_bounded(self, simple_schema, registry, collect_calls):
+    def test_collect_count_bounded(self, simple_schema, registry, collect_calls):
         """#11: guards against silently regaining wasted collects.
 
         4 today: _enforce_notnull, _enforce_check_raise, _build_errors, _build_report.
@@ -309,7 +309,7 @@ class TestFullPipeline:
 
         assert len(collect_calls) == 4
 
-    def test_validate_collect_count_is_bounded_with_coercion_active(self, registry, collect_calls):
+    def test_collect_count_bounded_with_coercion(self, registry, collect_calls):
         """Same guard as above, but for the path with coercion's own raise-check active.
 
         5 today: _enforce_notnull, _enforce_coercion_raise, _enforce_check_raise,
@@ -334,7 +334,7 @@ class TestFullPipeline:
 
         assert len(collect_calls) == 5
 
-    def test_small_dataframe_input_uses_default_engine(self, simple_schema, registry, collect_calls):
+    def test_small_df_uses_default_engine(self, simple_schema, registry, collect_calls):
         """Below schema.streaming_row_threshold, an eager DataFrame stays on the
         default engine -- streaming's fixed setup cost regresses small validations.
         """
@@ -344,7 +344,7 @@ class TestFullPipeline:
         assert collect_calls
         assert all(call.get("engine") == "in-memory" for call in collect_calls)
 
-    def test_large_dataframe_input_uses_streaming_engine(self, registry, collect_calls):
+    def test_large_df_streams(self, registry, collect_calls):
         schema = SchemaModel.from_dict(
             {
                 "streaming_row_threshold": 10,
@@ -357,7 +357,7 @@ class TestFullPipeline:
         assert collect_calls
         assert all(call.get("engine") == "streaming" for call in collect_calls)
 
-    def test_lazyframe_input_always_uses_streaming_engine(self, registry, collect_calls):
+    def test_lazyframe_input_streams(self, registry, collect_calls):
         """Unknown size (no free row count), and choosing lazy signals larger intent."""
         schema = SchemaModel.from_dict({"columns": {"age": {"dtype": "Int64", "nullable": True}}})
         lf = pl.LazyFrame({"age": [1, 2, 3]})
@@ -367,7 +367,7 @@ class TestFullPipeline:
         assert all(call.get("engine") == "streaming" for call in collect_calls)
 
     @pytest.mark.parametrize("mode", ["rows", "cells"])
-    def test_row_and_cell_error_modes_never_stream(self, registry, collect_calls, mode):
+    def test_rows_cells_never_stream(self, registry, collect_calls, mode):
         """#11 step 4: only pure reductions stream.
 
         The rows/cells error builders materialize row indices and failing values, so
@@ -837,7 +837,7 @@ class TestNullification:
         assert result.report.columns["age"].coercion_failures == 0
         assert result.report.columns["age"].nullified == 1
 
-    def test_both_coercion_and_check_nulls_coexist_under_streaming_aggregate(self, registry):
+    def test_coercion_and_check_nulls_under_streaming(self, registry):
         """#11 step 4: the streaming-engine aggregate collect in _apply_check_null must
         agree with the with_columns mutation that follows it on the same lazy graph.
         """

--- a/tests/engine/test_pipeline.py
+++ b/tests/engine/test_pipeline.py
@@ -4,6 +4,7 @@ import polars as pl
 import pytest
 
 from nyctea.engine.context import PipelineContext
+from nyctea.engine.observability import MetricsCollector
 from nyctea.engine.pipeline import PhaseType, PipelinePhase, ValidationPipeline
 from nyctea.exceptions import PipelineError
 from nyctea.schema.model import SchemaModel
@@ -139,3 +140,27 @@ def test_pipeline_repr():
     repr_str = repr(pipeline)
     assert "ValidationPipeline" in repr_str
     assert "1 phases" in repr_str
+
+
+def _context_with_row_index():
+    lf = pl.LazyFrame({"a": [1, 2, 3]}).with_row_index("__row_index__")
+    return PipelineContext(data=lf, schema=SchemaModel(columns={}), registry=Registry())
+
+
+def test_execute_phase_skips_metrics_collect_without_observers(collect_calls):
+    """#11 step 1: the per-phase metrics block must not collect when nothing observes it."""
+    pipeline = ValidationPipeline(phases=[SimplePhase(name="p1")])
+    pipeline.execute(_context_with_row_index())
+
+    assert len(collect_calls) == 0
+
+
+def test_execute_phase_collects_metrics_with_observers():
+    """The observer path still gets real metrics once the metrics block is guarded."""
+    collector = MetricsCollector()
+    pipeline = ValidationPipeline(phases=[SimplePhase(name="p1")], observers=[collector])
+    pipeline.execute(_context_with_row_index())
+
+    assert len(collector.phase_metrics) == 1
+    assert collector.phase_metrics[0].phase_name == "p1"
+    assert collector.phase_metrics[0].rows_processed == 3


### PR DESCRIPTION
This pull request introduces a hand-maintained `CHANGELOG.md` as the canonical source of release notes, clarifies release and changelog processes, and adds a new feature for memory-efficient validation using Polars' streaming engine for internal aggregates. It also updates documentation and code to support this feature, including a new `streaming_row_threshold` setting in `SchemaModel` and an `AggregateEngine` type alias. The validation pipeline now chooses the optimal engine for internal reductions based on data size, improving performance on large datasets.

**Changelog and Release Process Improvements**
- Added a curated `CHANGELOG.md` to the repository root, following Keep a Changelog format and Semantic Versioning, and updated documentation and release process to treat it as the canonical account of changes. GitHub Releases are now considered auto-generated, uncurated summaries. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R88) [[2]](diffhunk://#diff-fa0db9a55b8569a7b179178a7f989c632d228e8be73c92b029007fdb08ad778eL21-R27) [[3]](diffhunk://#diff-8424996a26c190166694ac26ee0b73a739336d460eb91bf93ce04fa993ef6710L6-R7) [[4]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L35-R35)

**Streaming Engine for Internal Aggregates**
- Introduced `SchemaModel.streaming_row_threshold` to control whether internal aggregate collects use Polars' streaming engine, reducing peak memory usage on large data. Default is 100,000 rows, configurable per schema. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R88) [[2]](diffhunk://#diff-bce5e613a40b10613bc2bba57ed76127aa46593a6d1fdc0585b8c8fcfb490716R20-R41) [[3]](diffhunk://#diff-a9d21da594f52384886623c5208601c93638513610906205e68204505a5fa8c5R182-R194)
- Added `AggregateEngine` type alias (`Literal["in-memory", "streaming"]`) and updated code to select the engine per `validate()` call, threading it through the pipeline via `PipelineContext.aggregate_engine`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R88) [[2]](diffhunk://#diff-162fc400c787e370ac96b9c11ab5432fcd6576bfd68cd9ab408bbd2b16465cdcR42-R51) [[3]](diffhunk://#diff-a9d21da594f52384886623c5208601c93638513610906205e68204505a5fa8c5R47-R49) [[4]](diffhunk://#diff-fc225567fc10870200f3c4095ccd76c7eeed47e813c95b0b30c1501c5ac53049L13-R13) [[5]](diffhunk://#diff-fc225567fc10870200f3c4095ccd76c7eeed47e813c95b0b30c1501c5ac53049R39-R50) [[6]](diffhunk://#diff-04be3d8f9465cc00ca9ce7120dd81281508fff1b975aa58ba3fa51672c0448e9L17-R17) [[7]](diffhunk://#diff-04be3d8f9465cc00ca9ce7120dd81281508fff1b975aa58ba3fa51672c0448e9R35-R65) [[8]](diffhunk://#diff-04be3d8f9465cc00ca9ce7120dd81281508fff1b975aa58ba3fa51672c0448e9R143-R146) [[9]](diffhunk://#diff-04be3d8f9465cc00ca9ce7120dd81281508fff1b975aa58ba3fa51672c0448e9R159)
- Refactored validation steps that perform internal reductions (e.g., check enforcement, error reporting) to use the selected aggregate engine, with a helper function `_collect_aggregate`. [[1]](diffhunk://#diff-04be3d8f9465cc00ca9ce7120dd81281508fff1b975aa58ba3fa51672c0448e9L186-R222) [[2]](diffhunk://#diff-04be3d8f9465cc00ca9ce7120dd81281508fff1b975aa58ba3fa51672c0448e9L247-R283) [[3]](diffhunk://#diff-04be3d8f9465cc00ca9ce7120dd81281508fff1b975aa58ba3fa51672c0448e9L276-R316) [[4]](diffhunk://#diff-611d6e757c94d12e15c6e4b8e608eb2180ff13b0a0d7d5cafa6477ec1286d5ceL616-R616)

**Other Improvements**
- The per-phase metrics block in the validation pipeline now only collects metrics if observers are registered, reducing unnecessary computation. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R88) [[2]](diffhunk://#diff-416e67acf9dd688aff47c84d392466c6338dcd3be426534068f1505f7e6a84f9R340-L347)

---

Closes #11
