### PR TITLE
fix: reserve internal check names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
+- User checks named `coerce` or `not_null` are now rejected in every schema configuration because those names identify built-in failures throughout enforcement and reporting (#71).
 - Absent optional columns now skip configured parsers and checks instead of failing with a missing-column error (#59).
 - Declaring two checks with the same name on one column now raises `PipelineError` instead of silently dropping the first one. `check_masks`, `result.errors`, and the report stats are all keyed on `(column, check name)`, so the second declaration overwrote the first and orphaned its mask, removing that check from both reporting and enforcement. A column declaring `between(0, 5)` under `on_failure: "raise"` would accept a value of `30` and report the dataset 100% valid. See [breaking changes](docs/releases/breaking-changes.md).
 - `on_failure` is now enforced for check failures, not only for coercion-introduced nulls. `raise` actually raises, and `null` actually nulls the failing value. Both were previously silent: the failure was recorded in `result.errors` while execution continued with the bad value still in the output (#9).

--- a/src/nyctea/engine/phases.py
+++ b/src/nyctea/engine/phases.py
@@ -503,7 +503,7 @@ class ColumnCheckPhase(PipelinePhase):
             if col_name not in current_columns:
                 continue
             for check_spec in col_schema.checks or []:
-                self._reject_reserved_or_duplicate_check(schema, check_masks, col_name, check_spec.name)
+                self._reject_reserved_or_duplicate_check(check_masks, col_name, check_spec.name)
                 check_expr = self._resolve_check_expr(registry, col_name, check_spec)
 
                 # Index, not "{col}__{check}": the latter is ambiguous, since a column named
@@ -545,7 +545,6 @@ class ColumnCheckPhase(PipelinePhase):
 
     def _reject_reserved_or_duplicate_check(
         self,
-        schema: SchemaModel,
         check_masks: dict[tuple[str, str], str],
         col_name: str,
         check_name: str,
@@ -553,20 +552,18 @@ class ColumnCheckPhase(PipelinePhase):
         """Reject check names that would collide in the (column, check) mask key.
 
         Args:
-            schema: The schema being validated.
             check_masks: Masks registered so far, keyed on (column, check name).
             col_name: Column the check is declared on.
             check_name: Declared name of the check.
 
         Raises:
-            PipelineError: If the name is reserved for coercion tracking, or if the
+            PipelineError: If the name is reserved for internal tracking, or if the
                 column already has a check registered under the same name.
         """
-        if check_name == COERCION_CHECK and schema.resolve_coerce(col_name):
+        if check_name in {COERCION_CHECK, NOT_NULL_CHECK}:
             raise PipelineError(
-                f"Column '{col_name}' has coercion enabled and also has a check named "
-                f"'{COERCION_CHECK}'. The name is reserved for the built-in coercion "
-                f"failure tracking. Rename the check.",
+                f"Column '{col_name}' has a check named '{check_name}'. The name is "
+                "reserved for built-in failure tracking. Rename the check.",
                 phase=self.name,
             )
 

--- a/src/nyctea/engine/phases.py
+++ b/src/nyctea/engine/phases.py
@@ -549,7 +549,7 @@ class ColumnCheckPhase(PipelinePhase):
         col_name: str,
         check_name: str,
     ) -> None:
-        """Reject check names that would collide in the (column, check) mask key.
+        """Reject check names reserved for internal failure tracking, or duplicate names per column.
 
         Args:
             check_masks: Masks registered so far, keyed on (column, check name).

--- a/tests/engine/test_phases.py
+++ b/tests/engine/test_phases.py
@@ -686,8 +686,8 @@ class TestFullPipeline:
         with pytest.raises(PipelineError, match="reserved"):
             schema.validate(pl.DataFrame({"age": [1, 300]}), registry)
 
-    def test_not_null_check_name_allowed_on_nullable_column(self, registry):
-        """The reservation only applies where the built-in constraint is generated."""
+    def test_not_null_check_name_is_reserved_on_nullable_column(self, registry):
+        """The name stays reserved because downstream consumers always treat it as internal."""
         decorators = ValidatorDecorator(registry)
 
         @decorators.column_check(name="not_null", tags=[])
@@ -697,8 +697,8 @@ class TestFullPipeline:
         schema = SchemaModel.from_dict(
             {"columns": {"age": {"dtype": "Int64", "nullable": True, "checks": [{"name": "not_null"}]}}}
         )
-        result = schema.validate(pl.DataFrame({"age": [1, 300]}), registry)
-        assert result.errors.filter(pl.col("check") == "not_null")["count"].item() == 1
+        with pytest.raises(PipelineError, match="reserved"):
+            schema.validate(pl.DataFrame({"age": [1, 300]}), registry)
 
     @pytest.mark.parametrize("mode", ["summary", "rows", "cells"])
     def test_not_null_reported_in_every_error_mode(self, registry, mode):
@@ -1128,6 +1128,25 @@ class TestNullification:
         schema = SchemaModel.from_dict(
             {
                 "coerce": True,
+                "columns": {
+                    "age": {"dtype": "Int64", "nullable": True, "checks": [{"name": "coerce"}]},
+                },
+            }
+        )
+        with pytest.raises(PipelineError, match="reserved"):
+            schema.validate(pl.DataFrame({"age": [1, 2]}), registry)
+
+    def test_coercion_check_name_is_reserved_when_coercion_is_disabled(self, registry):
+        """The name stays reserved because downstream consumers always treat it as internal."""
+        decorators = ValidatorDecorator(registry)
+
+        @decorators.column_check(name="coerce", tags=[])
+        def fake_coerce(column: pl.Expr) -> pl.Expr:
+            return column > 0
+
+        schema = SchemaModel.from_dict(
+            {
+                "coerce": False,
                 "columns": {
                     "age": {"dtype": "Int64", "nullable": True, "checks": [{"name": "coerce"}]},
                 },


### PR DESCRIPTION
This pull request strengthens the enforcement of reserved check names in schema configurations, ensuring that user-defined checks cannot use the names `coerce` or `not_null`, regardless of schema options. This change prevents conflicts with internal failure tracking and improves error reporting. The update also includes expanded test coverage and documentation.

### Enforcement of reserved check names

* User-defined checks named `coerce` or `not_null` are now always rejected in schema configurations, as these names are reserved for internal failure tracking. Attempting to use these names raises a `PipelineError` with a clear message. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR30) [[2]](diffhunk://#diff-611d6e757c94d12e15c6e4b8e608eb2180ff13b0a0d7d5cafa6477ec1286d5ceL548-R566)
* The method `_reject_reserved_or_duplicate_check` in `phases.py` was simplified to remove the dependency on the schema and now checks for both reserved names unconditionally. [[1]](diffhunk://#diff-611d6e757c94d12e15c6e4b8e608eb2180ff13b0a0d7d5cafa6477ec1286d5ceL506-R506) [[2]](diffhunk://#diff-611d6e757c94d12e15c6e4b8e608eb2180ff13b0a0d7d5cafa6477ec1286d5ceL548-R566)

### Test improvements

* Tests were updated to assert that using `not_null` or `coerce` as a check name on any column (including nullable columns or when coercion is disabled) raises a `PipelineError`, ensuring consistent enforcement. [[1]](diffhunk://#diff-cbed9af2ba967040ecf4a4f3d21714b5e951a574b1ee612baa2152321443db2bL689-R690) [[2]](diffhunk://#diff-cbed9af2ba967040ecf4a4f3d21714b5e951a574b1ee612baa2152321443db2bL700-R701) [[3]](diffhunk://#diff-cbed9af2ba967040ecf4a4f3d21714b5e951a574b1ee612baa2152321443db2bR1139-R1157)

### Documentation

* The `CHANGELOG.md` was updated to document that checks named `coerce` or `not_null` are now always rejected in every schema configuration.