### PR TITLE
fix: preserve frame parser validation invariants

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -61,9 +61,10 @@
 
 ## Related Issues
 
-<!-- Link to related issues using #issue_number -->
+<!-- Link the branch through the issue's Development section before opening the PR. -->
+<!-- Reference the issue here for context only. Do not use Closes, Fixes, or Resolves. -->
 
-Closes #
+Related: #
 
 ## Additional Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Fixed
 
+- Frame parsers can no longer remove required schema columns, and Nyctea now rebuilds private row tracking after frame transformations so every error report mode remains available (#62).
 - User checks named `coerce` or `not_null` are now rejected in every schema configuration because those names identify built-in failures throughout enforcement and reporting (#71).
 - Absent optional columns now skip configured parsers and checks instead of failing with a missing-column error (#59).
 - Declaring two checks with the same name on one column now raises `PipelineError` instead of silently dropping the first one. `check_masks`, `result.errors`, and the report stats are all keyed on `(column, check name)`, so the second declaration overwrote the first and orphaned its mask, removing that check from both reporting and enforcement. A column declaring `between(0, 5)` under `on_failure: "raise"` would accept a value of `30` and report the dataset 100% valid. See [breaking changes](docs/releases/breaking-changes.md).

--- a/src/nyctea/engine/phases.py
+++ b/src/nyctea/engine/phases.py
@@ -168,7 +168,8 @@ class FrameParsingPhase(PipelinePhase):
             PipelineError: If a frame parser is unregistered or fails.
         """
         registry = context.registry
-        lf = context.data
+        input_columns = context.data.collect_schema().names()
+        lf = context.data.drop("__row_index__") if "__row_index__" in input_columns else context.data
 
         for parser_spec in context.schema.frame_parsers:
             try:
@@ -188,7 +189,25 @@ class FrameParsingPhase(PipelinePhase):
                     phase=self.name,
                 ) from e
 
-        context.data = lf
+        output_columns = lf.collect_schema().names()
+        missing_required = [
+            col_name
+            for col_name, col_schema in context.schema.columns.items()
+            if col_schema.required and col_name not in output_columns
+        ]
+        if missing_required:
+            raise PipelineError(
+                f"Frame parsers removed required columns: {missing_required}",
+                phase=self.name,
+            )
+
+        _reject_alias_collision(
+            "__row_index__",
+            output_columns,
+            self.name,
+            "row tracking after frame parsing",
+        )
+        context.data = lf.with_row_index("__row_index__")
         return context
 
     def can_skip(self, context: PipelineContext) -> bool:

--- a/src/nyctea/engine/phases.py
+++ b/src/nyctea/engine/phases.py
@@ -190,10 +190,11 @@ class FrameParsingPhase(PipelinePhase):
                 ) from e
 
         output_columns = lf.collect_schema().names()
+        output_column_names = set(output_columns)
         missing_required = [
             col_name
             for col_name, col_schema in context.schema.columns.items()
-            if col_schema.required and col_name not in output_columns
+            if col_schema.required and col_name not in output_column_names
         ]
         if missing_required:
             raise PipelineError(

--- a/tests/engine/test_phases.py
+++ b/tests/engine/test_phases.py
@@ -1645,6 +1645,6 @@ def test_frame_parser_preserves_error_tracking(registry, mode):
     if mode == "summary":
         assert result.errors["count"].item() == 1
     elif mode == "rows":
-        assert result.errors["row_indices"].item().to_list() == [0]
+        assert result.errors["row_indices"].to_list() == [[0]]
     else:
         assert result.errors["row_index"].to_list() == [0]

--- a/tests/engine/test_phases.py
+++ b/tests/engine/test_phases.py
@@ -1589,3 +1589,62 @@ class TestOnFailure:
         data = result.data.collect()
         assert data["age"].to_list() == [None, 5]
         assert data["score"].to_list() == [-1, 5]
+
+
+def test_frame_parser_cannot_remove_required_column(registry):
+    decorators = ValidatorDecorator(registry)
+
+    @decorators.frame_parser(name="drop_required", preserve_columns=False)
+    def drop_required(frame: pl.LazyFrame) -> pl.LazyFrame:
+        return frame.drop("name")
+
+    schema = SchemaModel.from_dict(
+        {
+            "frame_parsers": [{"name": "drop_required"}],
+            "columns": {
+                "id": {"dtype": "Int64"},
+                "name": {"dtype": "Utf8"},
+            },
+        }
+    )
+
+    with pytest.raises(PipelineError, match=r"removed required columns: \['name'\]"):
+        schema.validate(pl.DataFrame({"id": [1], "name": ["Alice"]}), registry)
+
+
+@pytest.mark.parametrize("mode", ["summary", "rows", "cells"])
+def test_frame_parser_preserves_error_tracking(registry, mode):
+    decorators = ValidatorDecorator(registry)
+
+    @decorators.frame_parser(name="select_columns", preserve_columns=False)
+    def select_columns(frame: pl.LazyFrame) -> pl.LazyFrame:
+        assert "__row_index__" not in frame.collect_schema().names()
+        return frame.select("age")
+
+    schema = SchemaModel.from_dict(
+        {
+            "on_failure": "ignore",
+            "frame_parsers": [{"name": "select_columns"}],
+            "columns": {
+                "age": {
+                    "dtype": "Int64",
+                    "nullable": True,
+                    "checks": [{"name": "min_value", "args": {"min": 0}}],
+                }
+            },
+        }
+    )
+
+    result = schema.validate(
+        pl.DataFrame({"age": [-1, 2], "unused": ["x", "y"]}),
+        registry,
+        error_report_config=ErrorReportConfig(mode=mode),
+    )
+
+    assert result.report.rows_valid == 1
+    if mode == "summary":
+        assert result.errors["count"].item() == 1
+    elif mode == "rows":
+        assert result.errors["row_indices"].item().to_list() == [0]
+    else:
+        assert result.errors["row_index"].to_list() == [0]


### PR DESCRIPTION
This pull request strengthens data validation and error tracking in the Nyctea pipeline by ensuring that frame parsers cannot remove required schema columns and that row tracking is consistently rebuilt after frame transformations. It also updates documentation and adds comprehensive tests to verify these behaviors.

**Frame parser validation and error tracking:**

* Frame parsers are now prevented from removing required columns from the schema. If a required column is missing after parsing, a `PipelineError` is raised. (`src/nyctea/engine/phases.py`, [src/nyctea/engine/phases.pyL191-R210](diffhunk://#diff-611d6e757c94d12e15c6e4b8e608eb2180ff13b0a0d7d5cafa6477ec1286d5ceL191-R210))
* After frame parsing, private row tracking (`__row_index__`) is rebuilt to ensure all error report modes remain available. (`src/nyctea/engine/phases.py`, [src/nyctea/engine/phases.pyL191-R210](diffhunk://#diff-611d6e757c94d12e15c6e4b8e608eb2180ff13b0a0d7d5cafa6477ec1286d5ceL191-R210))

**Testing improvements:**

* Added tests to verify that frame parsers cannot remove required columns and that error tracking is preserved across different error report modes. (`tests/engine/test_phases.py`, [tests/engine/test_phases.pyR1592-R1650](diffhunk://#diff-cbed9af2ba967040ecf4a4f3d21714b5e951a574b1ee612baa2152321443db2bR1592-R1650))

**Documentation and changelog:**

* Updated the changelog to reflect the new frame parser restrictions and error tracking improvements. (`CHANGELOG.md`, [CHANGELOG.mdR30](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR30))
* Improved the pull request template to clarify how to reference related issues. (`.github/pull_request_template.md`, [.github/pull_request_template.mdL64-R67](diffhunk://#diff-b2496e80299b8c3150b1944450bd81c622e04e13d15c411d291db0927d75fd6bL64-R67))